### PR TITLE
fix readthedocs URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Documentation
 =============
 
 The full documentation including the API reference is published on
-`readthedocs <http://pyahocorasick.readthedocs.io/en/>`_.
+`readthedocs <http://pyahocorasick.readthedocs.io/en/latest/>`_.
 
 Quick start
 ===========

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Documentation
 =============
 
 The full documentation including the API reference is published on
-`readthedocs <http://pyahocorasick.readthedocs.io/en/latest/>`_.
+`readthedocs <http://pyahocorasick.readthedocs.io/>`_.
 
 Quick start
 ===========


### PR DESCRIPTION
Without the /latest/ suffix it was for some reason taking to the "Maze Found" / 404 page.