### PR TITLE
Fix bug while installing in non-UTF-8 environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def get_long_description():
     """
     Strip the content index from the long description.
     """
-    with open('README.rst', 'rt') as f:
+    with open('README.rst', 'rt', encoding='UTF-8') as f:
         readme = [line for line in f if not line.startswith('.. contents::')]
         return ''.join(readme)
 


### PR DESCRIPTION
Error description:

UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 13: ordinal not in range(128)