### PR TITLE
Added another pure python alternative

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,7 +188,8 @@ for Python you may consider these other libraries:
 * `ahocorapy <https://github.com/abusix/ahocorapy>`_ by abusix
 
  * Written in pure Python.
- * Better performance than py-aho-corasick. Using pypy search performance comparable to pyahocorasick.
+ * Better performance than py-aho-corasick.
+ * Using pypy, ahocorapy's search performance is only slightly worse than pyahocorasick's.
  * Performs additional suffix shortcutting (more setup overhead, less search overhead for suffix lookups).
  * Includes visualization tool for resulting automaton (using pygraphviz).
  * MIT-licensed, 100% test coverage, tested on all major python versions (+ pypy)

--- a/README.rst
+++ b/README.rst
@@ -185,7 +185,13 @@ for Python you may consider these other libraries:
 
  * Written in pure Python.
  * Poor performance.
+* `ahocorapy <https://github.com/abusix/ahocorapy>`_ by abusix
 
+ * Written in pure Python.
+ * Better performance than py-aho-corasick. Using pypy search performance comparable to pyahocorasick.
+ * Performs additional suffix shortcutting (more setup overhead, less search overhead for suffix lookups).
+ * Includes visualization tool for resulting automaton (using pygraphviz).
+ * MIT-licensed, 100% test coverage, tested on all major python versions (+ pypy)
 * `noaho <https://github.com/JDonner/NoAho>`_ by Jeff Donner
 
  * Written in C. Does not return overlapping matches.


### PR DESCRIPTION
Hi,
we (abusix) have recently decided to open source our pure python implementation of the Aho-Corasick algorithm. 
Its README also includes some performance comparisons and while your library is definitely the goto library, ahocorapy might also be useful for some people that need to stay clear of C-Extensions, are using pypy or need unicode support while using python2.7

Thanks for taking a look and it'd be nice to be included in your README, as it seems like a good place to find out a lot about Aho-Corasick implementations in python.