### PR TITLE
Add TokenAutomaton and extend iterator with methods to make it usable as a pointer like abstraction from Python

### DIFF
--- a/AutomatonSearchIter.c
+++ b/AutomatonSearchIter.c
@@ -364,6 +364,61 @@ automaton_search_iter_set(PyObject* self, PyObject* args) {
 }
 
 
+#define automaton_search_iter_is_root_doc \
+	"is_root()\n\n" \
+	"Check if iterator is currently at root node." 
+
+static PyObject*
+automaton_search_iter_is_root(PyObject* self, PyObject* args) {
+    if (iter->automaton->root == iter->state) {
+        Py_RETURN_TRUE;
+	} else {
+        Py_RETURN_FALSE;
+	}
+}
+
+
+#define automaton_search_iter_pos_id_doc \
+	"pos_id()\n\n" \
+	"Get an id corresponding to the current position." 
+
+static PyObject*
+automaton_search_iter_pos_id(PyObject* self, PyObject* args) {
+    return PyLong_FromVoidPtr(iter->state);
+}
+
+
+#define automaton_search_iter___copy___doc \
+	"__copy__()\n\n" \
+	"Check if iterator is currently at root node." 
+
+static PyObject*
+automaton_search_iter___copy__(PyObject* self, PyObject* args) {
+	AutomatonSearchIter* cpy;
+	cpy = (AutomatonSearchIter*)PyObject_New(AutomatonSearchIter, &automaton_search_iter_type);
+
+	cpy->automaton = iter->automaton;
+	cpy->version = iter->version;
+	cpy->input = iter->input;
+	cpy->state = iter->state;
+	cpy->output = iter->output;
+
+	cpy->input = iter->input;
+	cpy->index = iter->index;
+	cpy->shift = iter->shift;
+	cpy->end = iter->end;
+
+#ifdef VARIABLE_LEN_CHARCODES
+	cpy->position = iter->position;
+	cpy->expected = iter->expected;
+#endif
+
+	Py_INCREF(cpy->automaton);
+
+	return (PyObject*)cpy;
+}
+
+
 #undef iter
 
 #define method(name, kind) {#name, automaton_search_iter_##name, kind, automaton_search_iter_##name##_doc}
@@ -371,6 +426,9 @@ automaton_search_iter_set(PyObject* self, PyObject* args) {
 static
 PyMethodDef automaton_search_iter_methods[] = {
 	method(set, METH_VARARGS),
+	method(is_root, METH_NOARGS),
+	method(__copy__, METH_NOARGS),
+	method(pos_id, METH_NOARGS),
 
 	{NULL, NULL, 0, NULL}
 };

--- a/pyahocorasick.py
+++ b/pyahocorasick.py
@@ -1,0 +1,101 @@
+import ahocorasick
+from copy import copy
+
+
+class TokenAutomatonSearchIter(object):
+    def __init__(self, wrapped, index):
+        self.wrapped = wrapped
+        self.index = index
+
+    def is_root(self):
+        return self.wrapped.is_root()
+
+    def pos_id(self):
+        return self.wrapped.pos_id()
+
+    def set(self, string, *reset):
+        self.wrapped.set(self.index.convert_key(string), *reset)
+
+    def __copy__(self):
+        return TokenAutomatonSearchIter(copy(self.wrapped), self.index)
+
+    def __iter__(self):
+        return self.wrapped
+
+
+class TokenIndex(object):
+    def __init__(self):
+        self.index = {None: 0}
+        self.idx = 0
+
+    def add_get_token(self, token):
+        if token in self.index:
+            return self.index[token]
+        self.idx += 1
+        self.index[token] = self.idx
+        return self.idx
+
+    def get_token(self, token):
+        return self.index.get(token, 0)
+
+    def _convert_key(self, key, getter):
+        lst = []
+        for token in key:
+            lst.append(getter(token))
+        return tuple(lst)
+
+    def convert_key(self, key):
+        return self._convert_key(key, self.get_token)
+
+    def convert_add_key(self, key):
+        return self._convert_key(key, self.add_get_token)
+
+
+class TokenAutomaton(object):
+    """
+    Implements a similar interface to Automaton, but instead of dealing with
+    strings or tuples of integers, deals with tuples of tokens, that is strings
+    picked from some vocabulary.
+    """
+
+    def __init__(self, store=ahocorasick.STORE_ANY):
+        self.index = TokenIndex()
+        self.wrapped = ahocorasick.Automaton(store, ahocorasick.KEY_SEQUENCE)
+
+    def add_word(self, key, value):
+        self.wrapped.add_word(self.index.convert_add_key(key), value)
+
+    def iter(self, haystack, *args, **kwargs):
+        return TokenAutomatonSearchIter(
+            self.wrapped.iter(self.index.convert_key(haystack), *args, **kwargs),
+            self.index
+        )
+
+
+def mk_index_wrapped_meth(method_name):
+    def wrapper(self, key, *args, **kwargs):
+        wrapped = getattr(self.wrapped, method_name)
+        return wrapped(self.index.convert_key(key), *args, **kwargs)
+    return wrapper
+
+
+for method_name in [
+    "exists", "match", "get", "keys", "values", "items"
+]:
+    setattr(TokenAutomaton, method_name, mk_index_wrapped_meth(method_name))
+
+
+def mk_plain_wrapped_meth(method_name):
+    def wrapper(self, *args, **kwargs):
+        wrapped = getattr(self.wrapped, method_name)
+        return wrapped(*args, **kwargs)
+    return wrapper
+
+
+for method_name in [
+    "clear",
+    "make_automaton",
+    "get_stats",
+    "dump",
+]:
+    setattr(TokenAutomaton, method_name, mk_plain_wrapped_meth(method_name))

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     name='pyahocorasick',
     version='1.1.9.dev1',
     ext_modules=[module],
+    py_modules=['pyahocorasick'],
 
     description=(
         'pyahocorasick is a fast and memory efficient library for exact or '


### PR DESCRIPTION
So this is kind of a bad PR because it's two in one, but I developed them at the same time and there is a small amount of interdependence. If you want one thing but not the other, I can create a new PR. (I can also add more proper unit tests/docs at the same time -- after discussion.)

The TokenAutomaton is essentially the idea mentioned in https://github.com/WojciechMula/pyahocorasick/issues/27 . It's mostly just a convenience wrapper, hence it is written in Python. I don't think it should be too slow after building since it really just adds an extra dict lookup per token.

The second bit is kind of two parts:
  1. I want to be able to search through a haystack where each token may be one of multiple tokens. This automaton structure is called a confusion network. See: http://www.statmt.org/moses/img/mesh.png . I am dealing with the unweighted case. This is implemented in `conf_net_search`.
  2. To do this I had to enrich AutomatonSearchIter with some extra stuff to make it so it's more directly usable like a pointer. These could be generally useful for doing other things (most likely combining with different types of automaton).

See the code and docstrings within for more info.

Here is the code I've been using for testing:

```
import ahocorasick
from pyahocorasick import conf_net_search, TokenAutomaton
from copy import copy

a = ahocorasick.Automaton(ahocorasick.STORE_ANY, ahocorasick.KEY_SEQUENCE)
a.add_word((43, 89), (43, 89))
a.add_word((43, 89, 64), (43, 89, 64))
a.add_word((89, 64), (89, 64))
a.add_word((89, 100), (89, 100))
a.make_automaton()

for x in a.iter((80, 80, 43, 89, 90, 89, 64, 100, 43, 89, 100)):
    print(x)


confs = ((80,43),(80, 89),(64,43),(89,),(90,43),(89,),(64,100),(100,),(43,),(89,),(100,64))

print("confs")
for x in conf_net_search(a, confs):
    print(x)

a2 = TokenAutomaton()
a2.add_word("big pig fig".split(), "bpf")
a2.add_word("pig fig chig".split(), "pfc")
a2.add_word("big pig".split(), "bp")
a2.add_word("big fig".split(), "bf")
a2.make_automaton()

print(a2.index.index)
print(a2.index.tokens)

for x in a2.iter("big pig chig pig fig chig big pig".split()):
    print(x)


print("confs2")
confs2 = (("big", "pig"), ("fig",), ("chig", "flig", "drig", "pig"), ("fig",), ("chig", "wig"))
for x in conf_net_search(a2, confs2):
    print(x)
```