### PR TITLE
Introduce new trie representation

### DIFF
--- a/Automaton.c
+++ b/Automaton.c
@@ -568,6 +568,7 @@ automaton_make_automaton(PyObject* self, PyObject* args) {
     TrieNode* node;
     TrieNode* child;
     TrieNode* state;
+    TRIE_LETTER_TYPE letter;
 
 
     if (automaton->kind != TRIE)
@@ -605,7 +606,8 @@ automaton_make_automaton(PyObject* self, PyObject* args) {
         }
 
         for (i=0; i < node->n; i++) {
-            child = trienode_get_ith_unsafe(node, i);
+            child  = trienode_get_ith_unsafe(node, i);
+            letter = trieletter_get_ith_unsafe(node, i);
             ASSERT(child);
 
             item = (AutomatonQueueItem*)list_item_new(sizeof(AutomatonQueueItem));
@@ -620,13 +622,13 @@ automaton_make_automaton(PyObject* self, PyObject* args) {
             ASSERT(state);
             ASSERT(child);
             while (state != automaton->root and\
-                   not trienode_get_next(state, child->letter)) {
+                   not trienode_get_next(state, letter)) {
 
                 state = state->fail;
                 ASSERT(state);
             }
 
-            child->fail = trienode_get_next(state, child->letter);
+            child->fail = trienode_get_next(state, letter);
             if (child->fail == NULL)
                 child->fail = automaton->root;
 
@@ -1052,7 +1054,7 @@ dump_aux(TrieNode* node, const int depth, void* extra) {
     // 2.
     for (i=0; i < node->n; i++) {
         child = trienode_get_ith_unsafe(node, i);
-        tuple = F(Py_BuildValue)("ici", node, child->letter, child);
+        tuple = F(Py_BuildValue)("ici", node, trieletter_get_ith_unsafe(node, i), child);
         append_tuple(Dump->edges)
     }
 

--- a/AutomatonItemsIter.h
+++ b/AutomatonItemsIter.h
@@ -35,6 +35,7 @@ typedef struct AutomatonItemsIter {
     Automaton*  automaton;
     int         version;        ///< automaton version
     TrieNode*   state;          ///< current automaton node
+    TRIE_LETTER_TYPE letter;    ///< current letter
     List        stack;          ///< stack
     ItemsType   type;           ///< type of iterator (KEYS/VALUES/ITEMS)
     TRIE_LETTER_TYPE* buffer;   ///< buffer to construct key representation

--- a/runtest.sh
+++ b/runtest.sh
@@ -298,14 +298,14 @@ function handle_release
     # 2. build with memory debug and run unit tests and unpickle tests
     if true
     then
-        export CFLAGS="-DMEMORY_DEBUG"
+        export CFLAGS="${MEMORY_DEBUG}"
         force_rebuild > /dev/null 2>&1
 
-        rm -f memory.dump
+        rm -f ${MEMORY_DUMP_PATH}
         run_unittests
         run_leaktest
 
-        rm -f memory.dump
+        rm -f ${MEMORY_DUMP_PATH}
         run_unpickletests
         run_leaktest
     fi
@@ -313,7 +313,7 @@ function handle_release
     # 3. inject malloc faults
     if true
     then
-        export CFLAGS="-DMEMORY_DEBUG"
+        export CFLAGS="${MEMORY_DEBUG}"
         force_rebuild > /dev/null 2>&1
 
         run_mallocfaults

--- a/src/custompickle/custompickle.c
+++ b/src/custompickle/custompickle.c
@@ -4,7 +4,7 @@
 
 static const char CUSTOMPICKLE_MAGICK[16] = {
     'p', 'y', 'a', 'h', 'o', 'c', 'o', 'r', 'a', 's', 'i', 'c', 'k',    // signature
-    '0', '0', '1'                                                       // format version
+    '0', '0', '2'                                                       // format version
 };
 
 

--- a/src/custompickle/load/module_automaton_load.c
+++ b/src/custompickle/load/module_automaton_load.c
@@ -132,8 +132,8 @@ automaton_load_node(LoadBuffer* input) {
 
     // 3. load next pointers
     if (node->n > 0) {
-        size = sizeof(TrieNode*) * node->n;
-        node->next = (TrieNode**)memory_alloc(size);
+        size = sizeof(Pair) * node->n;
+        node->next = (Pair*)memory_alloc(size);
         if (UNLIKELY(node->next == NULL)) {
             PyErr_NoMemory();
             goto exception;
@@ -239,13 +239,12 @@ automaton_load_fixup_node(LoadBuffer* input, TrieNode* node) {
 
     if (node->n > 0) {
         for (i=0; i < node->n; i++) {
-            node->next[i] = lookup_address(input, node->next[i]);
-            if (UNLIKELY(node->next[i] == NULL)) {
+            node->next[i].child = lookup_address(input, node->next[i].child);
+            if (UNLIKELY(node->next[i].child == NULL)) {
                 return false;
             }
         }
     }
-
 
     return true;
 }

--- a/src/custompickle/save/automaton_save.c
+++ b/src/custompickle/save/automaton_save.c
@@ -101,7 +101,6 @@ automaton_save_node(TrieNode* node, const int depth, void* extra) {
 
     dump->n         = node->n;
     dump->eow       = node->eow;
-    dump->letter    = node->letter;
     dump->fail      = node->fail;
 
     // 3. pickle python value associated with word
@@ -116,7 +115,7 @@ automaton_save_node(TrieNode* node, const int depth, void* extra) {
             return 0;
         }
 
-        // store the size of buffer in trie node [which is not saved yet in a file]
+        // store the size of buffer in trie node [which is not saved yet in the file]
         *(size_t*)(&dump->output.integer) = PyBytes_GET_SIZE(bytes);
     } else {
         bytes = NULL;
@@ -124,7 +123,7 @@ automaton_save_node(TrieNode* node, const int depth, void* extra) {
 
     // 4. save array of pointers
     if (node->n > 0) {
-        savebuffer_store(output, (const char*)node->next, node->n * sizeof(PICKLE_POINTER_SIZE));
+        savebuffer_store(output, (const char*)node->next, node->n * sizeof(Pair));
     }
 
     // 5. save pickled data, if any

--- a/src/custompickle/save/savebuffer.c
+++ b/src/custompickle/save/savebuffer.c
@@ -12,7 +12,7 @@ savebuffer_init(SaveBuffer* output, PyObject* serializer, KeysStore store, const
     output->nodes_count = 0;
 
     if (PICKLE_SIZE_T_SIZE < sizeof(PyObject*)) {
-        // XXX: this must be reworked, likely to module level
+        // XXX: this must be reworked, likely moved to module level
         PyErr_SetString(PyExc_SystemError, "unable to save data due to technical reasons");
         return false;
     }

--- a/src/pickle/pickle.h
+++ b/src/pickle/pickle.h
@@ -4,7 +4,6 @@
 
 // We save all TrieNode's fields except the last one, which is a pointer to array,
 // as we're store that array just after the node
-#define PICKLE_TRIENODE_SIZE (sizeof(TrieNode) - sizeof(TrieNode**))
-#define PICKLE_POINTER_SIZE (sizeof(TrieNode*))
+#define PICKLE_TRIENODE_SIZE (sizeof(TrieNode) - sizeof(Pair*))
 #define PICKLE_SIZE_T_SIZE (sizeof(size_t))
 #define PICKLE_CHUNK_COUNTER_SIZE (sizeof(Py_ssize_t))

--- a/src/pycallfault/pycallfault.h
+++ b/src/pycallfault/pycallfault.h
@@ -32,6 +32,8 @@ int check_and_set_error(void);
 
 #define PyCallable_Check_custom(arg) (check() ? 0 : PyCallable_Check(arg))
 
+#define PyString_Check_custom(arg) (check() ? 0 : PyString_Check(arg))
+
 #define PyUnicode_Check_custom(arg) (check() ? 0 : PyUnicode_Check(arg))
 
 #define PyBytes_Check_custom(arg) (check() ? 0 : PyBytes_Check(arg))

--- a/trie.c
+++ b/trie.c
@@ -20,7 +20,7 @@ trie_add_word(Automaton* automaton, const TRIE_LETTER_TYPE* word, const size_t w
 
     if (automaton->kind == EMPTY) {
         ASSERT(automaton->root == NULL);
-        automaton->root = trienode_new('\0', false);
+        automaton->root = trienode_new(false);
         if (automaton->root == NULL)
             return NULL;
     }
@@ -32,7 +32,7 @@ trie_add_word(Automaton* automaton, const TRIE_LETTER_TYPE* word, const size_t w
 
         child = trienode_get_next(node, letter);
         if (child == NULL) {
-            child = trienode_new(letter, false);
+            child = trienode_new(false);
             if (LIKELY(child != NULL)) {
                 if (UNLIKELY(trienode_set_next(node, letter, child) == NULL)) {
                     memory_free(child);
@@ -201,7 +201,6 @@ trie_traverse_aux(
     void *extra
 ) {
     unsigned i;
-
     if (callback(node, depth, extra) == 0)
         return 0;
 

--- a/trienode.c
+++ b/trienode.c
@@ -11,7 +11,7 @@
 #include "trienode.h"
 
 static TrieNode*
-trienode_new(const TRIE_LETTER_TYPE letter, const char eow) {
+trienode_new(const char eow) {
     TrieNode* node = (TrieNode*)memory_alloc(sizeof(TrieNode));
     if (node) {
         node->output.integer = 0;
@@ -19,7 +19,6 @@ trienode_new(const TRIE_LETTER_TYPE letter, const char eow) {
         node->fail      = NULL;
 
         node->n     = 0;
-        node->letter    = letter;
         node->eow       = eow;
         node->next  = NULL;
     }
@@ -44,11 +43,15 @@ static TrieNode* PURE
 trienode_get_next(TrieNode* node, const TRIE_LETTER_TYPE letter) {
 
     unsigned i;
+    Pair* next;
 
     ASSERT(node);
+    next = (Pair*)node->next;
+
     for (i=0; i < node->n; i++)
-        if ((node)->next[i]->letter == letter)
-            return node->next[i];
+        if (next[i].letter == letter) {
+            return next[i].child;
+        }
 
     return NULL;
 }
@@ -59,11 +62,11 @@ trienode_unset_next_pointer(TrieNode* node, TrieNode* child) {
 
     unsigned i;
     unsigned index;
-    TrieNode** next;
+    Pair* next;
 
     ASSERT(node);
     for (i=0; i < node->n; i++) {
-        if (node->next[i] == child) {
+        if (node->next[i].child == child) {
             index = i;
             goto found;
         }
@@ -82,7 +85,7 @@ found:
 
     // there are more nodes, reallocation is needed
 
-    next = (TrieNode**)memory_alloc((node->n - 1) * sizeof(TrieNode*));
+    next = (Pair*)memory_alloc((node->n - 1) * sizeof(Pair));
     if (UNLIKELY(next == NULL)) {
         return MEMORY_ERROR;
     }
@@ -106,7 +109,15 @@ static TrieNode* PURE
 trienode_get_ith_unsafe(TrieNode* node, size_t index) {
     ASSERT(node);
 
-    return node->next[index];
+    return node->next[index].child;
+}
+
+
+static TRIE_LETTER_TYPE PURE
+trieletter_get_ith_unsafe(TrieNode* node, size_t index) {
+    ASSERT(node);
+
+    return node->next[index].letter;
 }
 
 
@@ -114,17 +125,19 @@ static TrieNode*
 trienode_set_next(TrieNode* node, const TRIE_LETTER_TYPE letter, TrieNode* child) {
 
     int n;
-    TrieNode** next;
+    void* next;
 
     ASSERT(node);
     ASSERT(child);
     ASSERT(trienode_get_next(node, letter) == NULL);
 
     n = node->n;
-    next = (TrieNode**)memory_realloc(node->next, (n + 1) * sizeof(TrieNode*));
+    next = (TrieNode**)memory_realloc(node->next, (n + 1) * (sizeof(Pair)));
     if (next) {
+
         node->next = next;
-        node->next[n] = child;
+        node->next[n].letter = letter;
+        node->next[n].child = child;
         node->n += 1;
 
         return child;
@@ -136,17 +149,20 @@ trienode_set_next(TrieNode* node, const TRIE_LETTER_TYPE letter, TrieNode* child
 
 #ifdef DEBUG_LAYOUT
 void trienode_dump_layout() {
-#define field_size(name) sizeof(((TrieNode*)NULL)->name)
-#define field_ofs(name) offsetof(TrieNode, name)
-#define field_dump(name) printf("- %-12s: %d %d\n", #name, field_size(name), field_ofs(name));
+#define field_size(TYPE, name) sizeof(((TYPE*)NULL)->name)
+#define field_ofs(TYPE, name) offsetof(TYPE, name)
+#define field_dump(TYPE, name) printf("- %-12s: %d %d\n", #name, field_size(TYPE, name), field_ofs(TYPE, name));
 
-    puts("TrieNode:");
-    field_dump(output);
-    field_dump(fail);
-    field_dump(n);
-    field_dump(eow);
-    field_dump(letter);
-    field_dump(next);
+    printf("TrieNode (size=%lu):\n", sizeof(TrieNode));
+    field_dump(TrieNode, output);
+    field_dump(TrieNode, fail);
+    field_dump(TrieNode, n);
+    field_dump(TrieNode, eow);
+    field_dump(TrieNode, next);
+
+    printf("Pair (size=%lu):\n", sizeof(Pair));
+    field_dump(Pair, letter);
+    field_dump(Pair, child);
 
 #undef field_dump
 #undef field_size
@@ -157,7 +173,6 @@ void trienode_dump_layout() {
 
 UNUSED static void
 trienode_dump_to_file(TrieNode* node, FILE* f) {
-
     unsigned i;
 
     ASSERT(node != NULL);
@@ -167,7 +182,6 @@ trienode_dump_to_file(TrieNode* node, FILE* f) {
         fprintf(f, "leaf ");
 
     fprintf(f, "node %p\n", node);
-    fprintf(f, "- letter %d [%c]\n", node->letter, node->letter);
     if (node->eow)
         fprintf(f, "- eow [%p]\n", node->output.object);
 
@@ -176,9 +190,9 @@ trienode_dump_to_file(TrieNode* node, FILE* f) {
         if (node->next == NULL) {
             fprintf(f, "- %d next: %p\n", node->n, node->next);
         } else {
-            fprintf(f, "- %d next: [%p", node->n, node->next[0]);
+            fprintf(f, "- %d next: [(%d; %p)", node->n, node->next[0].letter, node->next[0].child);
             for (i=1; i < node->n; i++)
-                fprintf(f, ", %p", node->next[i]);
+                fprintf(f, ", (%d; %p)", node->next[i].letter, node->next[i].child);
             fprintf(f, "]\n");
         }
     }

--- a/trienode.h
+++ b/trienode.h
@@ -13,6 +13,17 @@
 
 #include "common.h"
 
+struct TrieNode;
+
+
+#pragma pack(push)
+#pragma pack(1)
+typedef struct Pair {
+    TRIE_LETTER_TYPE letter;    ///< edge label
+    struct TrieNode* child;     ///< next pointer
+} Pair;
+#pragma pack(pop)
+
 /* links to children nodes are stored in dynamic table */
 typedef struct TrieNode {
     union {
@@ -27,9 +38,7 @@ typedef struct TrieNode {
     uint32_t            n;      ///< length of next
 #endif
     uint8_t             eow;    ///< end of word marker
-    TRIE_LETTER_TYPE    letter; ///< incoming edge label
-
-    struct TrieNode**   next;   ///< table of pointers
+    Pair*               next;   ///< table of letters and associated next pointers
 } TrieNode;
 
 
@@ -42,7 +51,7 @@ typedef enum {
 
 /* allocate new node */
 static TrieNode*
-trienode_new(const TRIE_LETTER_TYPE letter, const char eow);
+trienode_new(const char eow);
 
 /* free node */
 static void
@@ -62,6 +71,9 @@ trienode_unset_next_pointer(TrieNode* node, TrieNode* child);
 
 static TrieNode* PURE
 trienode_get_ith_unsafe(TrieNode* node, size_t letter);
+
+static TRIE_LETTER_TYPE PURE
+trieletter_get_ith_unsafe(TrieNode* node, size_t letter);
 
 #define trienode_is_leaf(node) ((node)->n == 0)
 


### PR DESCRIPTION
Python 3.7.2 from Debian

Memory usage for 250k words is sligtly better: master = 124407808 (118.64 MB), new representation = 124260352 (118.50 MB).

Benchmark comparison (`benchmarks/benchmark3.py`)

```
----------------------------------------------------------------------------------------
                                        |  master     | new representation |  speed-up
----------------------------------------------------------------------------------------
Generating data (1000000 words)         |  33.440 s   |         33.930 s   |    ---
Add words                               |   2.764 s   |          1.689 s   |  1.63 x 
Building automaton                      |  24.739 s   |         10.921 s   |  2.26 x
Look up                                 |   4.898 s   |          2.474 s   |  1.97 x
Search                                  |   1.480 s   |          0.544 s   |  2.72 x
```