### PR TITLE
Tentative Cygwin support

### DIFF
--- a/common.h
+++ b/common.h
@@ -21,7 +21,11 @@
 #if defined(_MSC_VER)       // Visual Studio compiler
 #   include "windows.h"
 #else
-#   include "posix.h"
+#   if defined(__CYGWIN__)
+#        include "cygwin.h"
+#   else
+#        include "posix.h"
+#   endif
 #endif
 
 #if PY_MAJOR_VERSION >= 3

--- a/cygwin.h
+++ b/cygwin.h
@@ -1,0 +1,17 @@
+/*
+    This is part of pyahocorasick Python module.
+    
+    CYGWIN declarations.
+
+    Author    : Wojciech Muła, wojciech_mula@poczta.onet.pl
+    WWW       : http://0x80.pl
+    License   : BSD-3-Clause (see LICENSE)
+*/
+
+#ifndef PYAHCORASICK_CYGWIN_H__
+#define PYAHCORASICK_CYGWIN_H__
+
+#define PY_OBJECT_HEAD_INIT PyVarObject_HEAD_INIT(NULL, 0)
+
+#endif
+

--- a/posix.h
+++ b/posix.h
@@ -1,7 +1,7 @@
 /*
     This is part of pyahocorasick Python module.
     
-    POSXI declarations.
+    POSIX declarations.
 
     Author    : Wojciech Muła, wojciech_mula@poczta.onet.pl
     WWW       : http://0x80.pl


### PR DESCRIPTION
Cygwin needs `PyVarObject_HEAD_INIT(NULL` as Windows, but does not need `msinttypes/stdint.h`.