### PR TITLE
docs: fix simple typo, shuld -> should

### DIFF
--- a/unpickle_test.py
+++ b/unpickle_test.py
@@ -400,7 +400,7 @@ class TestUnpickleRaw(unittest.TestCase):
     def test__wrong_type_of_chunk_container(self):
 
         self.count = 9
-        self.raw   = () # this shuld be a list
+        self.raw   = () # this should be a list
         self.kind  = ahocorasick.TRIE
         self.values = None
         self.word_count = 5


### PR DESCRIPTION
There is a small typo in unpickle_test.py.

Should read `should` rather than `shuld`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md