### PR TITLE
Rework pattern matching to use glob-style patterns

### DIFF
--- a/src/AutomatonItemsIter.c
+++ b/src/AutomatonItemsIter.c
@@ -15,21 +15,75 @@ static PyTypeObject automaton_items_iter_type;
 typedef struct AutomatonItemsStackItem {
     LISTITEM_data;
 
-    struct TrieNode*    node;
-    TRIE_LETTER_TYPE    letter;
+    struct TrieNode* node;
+    TRIE_LETTER_TYPE letter;
     size_t depth;
+    bool escaped;
+
+#ifdef AHOCORASICK_UNICODE
+    TRIE_LETTER_TYPE* prefix;   ///< buffer to construct key representation
+#else
+    char* prefix;
+#endif
+    size_t prefix_len;
+
 } AutomatonItemsStackItem;
 
 #define StackItem AutomatonItemsStackItem
+
+
+static StackItem *
+create_stack_item(Automaton* automaton) {
+    StackItem* new_item = (StackItem*)list_item_new(sizeof(StackItem));
+    if (UNLIKELY(new_item == NULL)) {
+        goto no_memory;
+    }
+
+    new_item->node = automaton->root;
+    new_item->depth = 0;
+    new_item->escaped = false;
+    new_item->prefix = NULL;
+    new_item->prefix_len = 0;
+    return new_item;
+
+no_memory:
+    PyErr_NoMemory();
+    return NULL;
+}
+
+
+static void
+memory_free_stack_item(StackItem *item) {
+    memory_safefree(item->prefix);
+    memory_free(item);
+}
+
+
+static void
+stack_item_set_prefix(StackItem* item, const void* prefix, size_t prefix_len, const TRIE_LETTER_TYPE* matched_letter) {
+    item->prefix = memory_realloc(item->prefix, (prefix_len + 1) * sizeof *(item->prefix));
+    if (item->prefix == NULL) {
+        goto no_memory;
+    }
+    memcpy(item->prefix, prefix, prefix_len * sizeof *(item->prefix));
+    item->prefix_len = prefix_len;
+
+    if (matched_letter != NULL) {
+        item->prefix[item->prefix_len] = *matched_letter;
+        item->prefix_len += 1;
+    }
+    return;
+
+no_memory:
+    PyErr_NoMemory();
+}
+
 
 static PyObject*
 automaton_items_iter_new(
     Automaton* automaton,
     const TRIE_LETTER_TYPE* word,
     const Py_ssize_t wordlen,
-
-    const bool use_wildcard,
-    const TRIE_LETTER_TYPE wildcard,
     const PatternMatchType matchtype
 ) {
     AutomatonItemsIter* iter;
@@ -43,29 +97,11 @@ automaton_items_iter_new(
     iter->version   = automaton->version;
     iter->state = NULL;
     iter->type = ITER_KEYS;
-    iter->buffer = NULL;
-#ifndef AHOCORASICK_UNICODE
-    iter->char_buffer = NULL;
-#endif
     iter->pattern = NULL;
-    iter->use_wildcard = use_wildcard;
-    iter->wildcard = wildcard;
     iter->matchtype = matchtype;
     list_init(&iter->stack);
 
     Py_INCREF((PyObject*)iter->automaton);
-
-    iter->buffer = memory_alloc((automaton->longest_word + 1) * TRIE_LETTER_SIZE);
-    if (iter->buffer == NULL) {
-        goto no_memory;
-    }
-
-#ifndef AHOCORASICK_UNICODE
-    iter->char_buffer = memory_alloc(automaton->longest_word + 1);
-    if (iter->char_buffer == NULL) {
-        goto no_memory;
-    }
-#endif
 
     if (word) {
         iter->pattern = (TRIE_LETTER_TYPE*)memory_alloc(wordlen * TRIE_LETTER_SIZE);
@@ -80,13 +116,10 @@ automaton_items_iter_new(
     else
         iter->pattern_length = 0;
 
-    new_item = (StackItem*)list_item_new(sizeof(StackItem));
+    new_item = create_stack_item(automaton);
     if (UNLIKELY(new_item == NULL)) {
         goto no_memory;
     }
-
-    new_item->node = automaton->root;
-    new_item->depth = 0;
     list_push_front(&iter->stack, (ListItem*)new_item);
 
     return (PyObject*)iter;
@@ -102,12 +135,15 @@ no_memory:
 
 static void
 automaton_items_iter_del(PyObject* self) {
-    memory_safefree(iter->buffer);
     memory_safefree(iter->pattern);
-#ifndef AHOCORASICK_UNICODE
-    memory_safefree(iter->char_buffer);
-#endif
 
+    while (true) {
+        StackItem* item = (StackItem*)list_pop_first(&iter->stack);
+        if (item == NULL) {
+            break;
+        }
+        memory_free_stack_item(item);
+    }
     list_delete(&iter->stack);
     Py_DECREF(iter->automaton);
 
@@ -124,11 +160,16 @@ automaton_items_iter_iter(PyObject* self) {
 
 static PyObject*
 automaton_items_iter_next(PyObject* self) {
-
-    bool output;
     TrieNode* node;
     TRIE_LETTER_TYPE letter;
     size_t depth;
+#ifdef AHOCORASICK_UNICODE
+    TRIE_LETTER_TYPE *prefix;
+#else
+    char *prefix;
+#endif
+    size_t prefix_len;
+    bool escaped;
 
     if (UNLIKELY(iter->version != iter->automaton->version)) {
         PyErr_SetString(PyExc_ValueError, "The underlying automaton has changed: this iterator is no longer valid.");
@@ -141,95 +182,173 @@ automaton_items_iter_next(PyObject* self) {
             return NULL; /* Stop iteration */
 
         if (top->node == NULL) {
-            memory_free(top);
+            memory_free_stack_item(top);
             return NULL; /* Stop iteration */
         }
 
-        node   = top->node;
+        node = top->node;
         letter = top->letter;
-        depth  = top->depth;
-        memory_free(top);
-
-        if (iter->matchtype != MATCH_AT_LEAST_PREFIX and depth > iter->pattern_length)
-            continue;
-
-        switch (iter->matchtype) {
-            case MATCH_EXACT_LENGTH:
-                output = (depth == iter->pattern_length);
-                break;
-
-            case MATCH_AT_MOST_PREFIX:
-                output = (depth <= iter->pattern_length);
-                break;
-
-            case MATCH_AT_LEAST_PREFIX:
-            default:
-                output = (depth >= iter->pattern_length);
-                break;
-
-        }
+        depth = top->depth;
+        escaped = top->escaped;
+        prefix = top->prefix;
+        prefix_len = top->prefix_len;
 
         iter->state  = node;
         iter->letter = letter;
-        if ((depth >= iter->pattern_length) or
-            (iter->use_wildcard and iter->pattern[depth] == iter->wildcard)) {
 
-            // process all
+        if ((iter->pattern_length == 0)
+            or (depth >= iter->pattern_length and iter->matchtype == MATCH_PREFIX)) {
+            // match all
             const int n = iter->state->n;
             int i;
             for (i=0; i < n; i++) {
-                StackItem* new_item = (StackItem*)list_item_new(sizeof(StackItem));
+                StackItem *new_item = create_stack_item(iter->automaton);
                 if (UNLIKELY(new_item == NULL)) {
+                    memory_free_stack_item(top);
+                    PyErr_NoMemory();
+                    return NULL;
+                }
+                new_item->node = trienode_get_ith_unsafe(iter->state, i);
+                new_item->letter = trieletter_get_ith_unsafe(iter->state, i);
+                new_item->depth = depth + 1;
+                new_item->escaped = false;
+                if (iter->type != ITER_VALUES) {
+                    stack_item_set_prefix(new_item, prefix, prefix_len, &new_item->letter);
+                }
+                list_push_front(&iter->stack, (ListItem*)new_item);
+            }
+        }
+        else if (depth < iter->pattern_length and iter->pattern[depth] == '\\' and !escaped) {
+            // Skip escape character and block next iteration from processing a wildcard
+            StackItem *new_item = create_stack_item(iter->automaton);
+            if (UNLIKELY(new_item == NULL)) {
+                memory_free_stack_item(top);
+                PyErr_NoMemory();
+                return NULL;
+            }
+
+            new_item->node = node;
+            new_item->letter = letter;
+            new_item->depth = depth + 1;
+            new_item->escaped = true;
+            if (iter->type != ITER_VALUES) {
+                stack_item_set_prefix(new_item, prefix, prefix_len, NULL);
+            }
+            list_push_front(&iter->stack, (ListItem*)new_item);
+
+        }
+        else if (depth < iter->pattern_length and iter->pattern[depth] == '?' and !escaped) {
+            // match any single character
+            const int n = iter->state->n;
+            if (n < 1) {
+                // no match
+                memory_free_stack_item(top);
+                continue;
+            }
+
+            int i;
+            for (i=0; i < n; i++) {
+                StackItem *new_item = create_stack_item(iter->automaton);
+                if (UNLIKELY(new_item == NULL)) {
+                    memory_free_stack_item(top);
                     PyErr_NoMemory();
                     return NULL;
                 }
 
-                new_item->node   = trienode_get_ith_unsafe(iter->state, i);
+                new_item->node = trienode_get_ith_unsafe(iter->state, i);
                 new_item->letter = trieletter_get_ith_unsafe(iter->state, i);
-                new_item->depth  = depth + 1;
+                new_item->depth = depth + 1;
+                new_item->escaped = false;
+                if (iter->type != ITER_VALUES) {
+                    stack_item_set_prefix(new_item, prefix, prefix_len, &new_item->letter);
+                }
                 list_push_front(&iter->stack, (ListItem*)new_item);
             }
         }
-        else {
-            // process single letter
+        else if (depth < iter->pattern_length and iter->pattern[depth] == '*' and !escaped) {
+            // match zero children and skip wildcard
+            StackItem *new_item = create_stack_item(iter->automaton);
+            if (UNLIKELY(new_item == NULL)) {
+                memory_free_stack_item(top);
+                PyErr_NoMemory();
+                return NULL;
+            }
+
+            new_item->node = node;
+            new_item->letter = letter;
+            new_item->depth = depth + 1;
+            new_item->escaped = false;
+            if (iter->type != ITER_VALUES) {
+                stack_item_set_prefix(new_item, prefix, prefix_len, NULL);
+            }
+            list_push_front(&iter->stack, (ListItem*)new_item);
+
+            // match all children and retain wildcard
+            const int n = iter->state->n;
+            int i;
+            for (i=0; i < n; i++) {
+                StackItem *new_item = create_stack_item(iter->automaton);
+                if (UNLIKELY(new_item == NULL)) {
+                    memory_free_stack_item(top);
+                    PyErr_NoMemory();
+                    return NULL;
+                }
+
+                new_item->node = trienode_get_ith_unsafe(iter->state, i);
+                new_item->letter = trieletter_get_ith_unsafe(iter->state, i);
+                new_item->depth = depth;
+                new_item->escaped = false;
+                if (iter->type != ITER_VALUES) {
+                    stack_item_set_prefix(new_item, prefix, prefix_len, &new_item->letter);
+                }
+                list_push_front(&iter->stack, (ListItem*)new_item);
+            }
+        }
+        else if (depth < iter->pattern_length) {
+            // match single letter
             TrieNode* node = trienode_get_next(iter->state, iter->pattern[depth]);
 
             if (node) {
-                StackItem* new_item = (StackItem*)list_item_new(sizeof(StackItem));
+                StackItem *new_item = create_stack_item(iter->automaton);
                 if (UNLIKELY(new_item == NULL)) {
+                    memory_free_stack_item(top);
                     PyErr_NoMemory();
                     return NULL;
                 }
 
-                new_item->node   = node;
+                new_item->node = node;
                 new_item->letter = iter->pattern[depth];
-                new_item->depth  = depth + 1;
+                new_item->depth = depth + 1;
+                new_item->escaped = false;
+                if (iter->type != ITER_VALUES) {
+                    stack_item_set_prefix(new_item, prefix, prefix_len, &new_item->letter);
+                }
                 list_push_front(&iter->stack, (ListItem*)new_item);
             }
         }
 
-        if (iter->type != ITER_VALUES) {
-            // update keys when needed
-            iter->buffer[depth] = iter->letter;
-#ifndef AHOCORASICK_UNICODE
-            iter->char_buffer[depth] = (char)iter->letter;
-#endif
-        }
-
-        if (output and iter->state->eow) {
+        if (depth >= iter->pattern_length and iter->state->eow) {
+            PyObject* result;
             PyObject* val;
 
             switch (iter->type) {
                 case ITER_KEYS:
 #if defined PEP393_UNICODE
-                    return F(PyUnicode_FromKindAndData)(PyUnicode_4BYTE_KIND, (void*)(iter->buffer + 1), depth);
+                    result = F(PyUnicode_FromKindAndData)(PyUnicode_4BYTE_KIND, (void*)(prefix), prefix_len);
+                    memory_free_stack_item(top);
+                    return result;
 #elif defined AHOCORASICK_UNICODE
-                    return PyUnicode_FromUnicode((Py_UNICODE*)(iter->buffer + 1), depth);
+                    result = PyUnicode_FromUnicode((Py_UNICODE*)(prefix), prefix_len);
+                    memory_free_stack_item(top);
+                    return result;
 #else
-                    return PyBytes_FromStringAndSize(iter->char_buffer + 1, depth);
+                    result = PyBytes_FromStringAndSize(prefix, prefix_len);
+                    memory_free_stack_item(top);
+                    return result;
 #endif
 
                 case ITER_VALUES:
+                    memory_free_stack_item(top);
                     switch (iter->automaton->store) {
                         case STORE_ANY:
                             val = iter->state->output.object;
@@ -250,40 +369,48 @@ automaton_items_iter_next(PyObject* self) {
                 case ITER_ITEMS:
                     switch (iter->automaton->store) {
                         case STORE_ANY:
-                            return F(Py_BuildValue)(
+                            result = F(Py_BuildValue)(
 #ifdef PY3K
     #ifdef AHOCORASICK_UNICODE
-                                "(u#O)", /*key*/ iter->buffer + 1, depth,
+                                "(u#O)", /*key*/ prefix, prefix_len,
     #else
-                                "(y#O)", /*key*/ iter->buffer + 1, depth,
+                                "(y#O)", /*key*/ prefix, prefix_len,
     #endif
 #else
-                                "(s#O)", /*key*/ iter->char_buffer + 1, depth,
+                                "(s#O)", /*key*/ prefix, prefix_len,
 #endif
                                 /*val*/ iter->state->output.object
                             );
+                            memory_free_stack_item(top);
+                            return result;
 
                         case STORE_LENGTH:
                         case STORE_INTS:
-                            return F(Py_BuildValue)(
+                            result = F(Py_BuildValue)(
 #ifdef PY3K
     #ifdef AHOCORASICK_UNICODE
-                                "(u#i)", /*key*/ iter->buffer + 1, depth,
+                                "(u#i)", /*key*/ prefix, prefix_len,
     #else
-                                "(y#i)", /*key*/ iter->buffer + 1, depth,
+                                "(y#i)", /*key*/ prefix, prefix_len,
     #endif
 #else
-                                "(s#i)", /*key*/ iter->char_buffer + 1, depth,
+                                "(s#i)", /*key*/ prefix, prefix_len,
 #endif
                                 /*val*/ iter->state->output.integer
                             );
+                            memory_free_stack_item(top);
+                            return result;
 
                         default:
                             PyErr_SetString(PyExc_SystemError, "Incorrect 'store' attribute.");
+                            memory_free_stack_item(top);
                             return NULL;
                     } // switch
             }
         }
+
+        // done with top for this iteration, free it
+        memory_free_stack_item(top);
     }
 }
 

--- a/src/AutomatonItemsIter.h
+++ b/src/AutomatonItemsIter.h
@@ -23,9 +23,8 @@ typedef enum {
 } ItemsType;
 
 typedef enum {
-    MATCH_EXACT_LENGTH,
-    MATCH_AT_MOST_PREFIX,
-    MATCH_AT_LEAST_PREFIX
+    MATCH_PREFIX,
+    MATCH_WHOLE,
 } PatternMatchType;
 
 
@@ -38,15 +37,9 @@ typedef struct AutomatonItemsIter {
     TRIE_LETTER_TYPE letter;    ///< current letter
     List        stack;          ///< stack
     ItemsType   type;           ///< type of iterator (KEYS/VALUES/ITEMS)
-    TRIE_LETTER_TYPE* buffer;   ///< buffer to construct key representation
-#ifndef AHOCORASICK_UNICODE
-    char        *char_buffer;
-#endif
 
     size_t pattern_length;
     TRIE_LETTER_TYPE* pattern;  ///< pattern
-    bool use_wildcard;
-    TRIE_LETTER_TYPE wildcard;  ///< wildcard char
     PatternMatchType matchtype; ///< how pattern have to be handled
 } AutomatonItemsIter;
 
@@ -57,10 +50,6 @@ automaton_items_iter_new(
     Automaton* automaton,
     const TRIE_LETTER_TYPE* word,
     const Py_ssize_t wordlen,
-
-    const bool use_wildcard,
-    const TRIE_LETTER_TYPE wildcard,
-
     const PatternMatchType  matchtype
 );
 

--- a/src/inline_doc.h
+++ b/src/inline_doc.h
@@ -136,10 +136,10 @@
 	"  pointer)."
 
 #define automaton_items_doc \
-	"items([prefix, [wildcard, [how]]])\n" \
+	"items([pattern, [how]])\n" \
 	"\n" \
 	"Return an iterator on tuples of (key, value). Keys are\n" \
-	"matched optionally to the prefix using the same logic and\n" \
+	"matched optionally to the pattern using the same logic and\n" \
 	"arguments as in the keys() method."
 
 #define automaton_iter_doc \
@@ -176,23 +176,26 @@
 	"the search to an input string slice as in string[start:end]."
 
 #define automaton_keys_doc \
-	"keys([prefix, [wildcard, [how]]])\n" \
+	"keys([pattern, [how]])\n" \
 	"\n" \
-	"Return an iterator on keys. If the optional prefix string is\n" \
-	"provided, only yield keys starting with this prefix.\n" \
+	"Return an iterator on keys. If the optional pattern string is\n" \
+	"provided, only yield keys starting with this pattern.\n" \
 	"\n" \
-	"If the optional wildcard is provided as a single character\n" \
-	"string, then the prefix is treated as a simple pattern using\n" \
-	"this character as a wildcard.\n" \
+	"The pattern can contain the following Unix shell-style wildcards:\n" \
+	"- ?: matches any single character.\n" \
+	"- *: matches everything.\n" \
 	"\n" \
-	"The optional how argument is used to control how strings are\n" \
+	"The '\\' character is reserved as the escape character. For example,\n" \
+	"r'\\*' matches the literal '*' character. Each literal backslash must\n" \
+	"be either expressed as '\\\\' or as a raw r'\\' string. For example,\n" \
+	"r'\\t' matches '\\t'.'\n" \
+	"\n" \
+	"The optional 'how' argument is used to control how patterns are\n" \
 	"matched using one of these possible values:\n" \
-	"- ahocorasick.MATCH_EXACT_LENGTH (default) Yield matches\n" \
-	"  that have the same exact length as the prefix length.\n" \
-	"- ahocorasick.MATCH_AT_LEAST_PREFIX Yield matches that have\n" \
-	"  a length greater or equal to the prefix length.\n" \
-	"- ahocorasick.MATCH_AT_MOST_PREFIX Yield matches that have a\n" \
-	"  length lesser or equal to the prefix length."
+	"- ahocorasick.MATCH_PREFIX (default): Yield keys with prefixes\n" \
+	"  that match the given pattern.\n" \
+	"- ahocorasick.MATCH_WHOLE: Yield keys that fully match\n" \
+	"  the given pattern."
 
 #define automaton_len_doc \
 	"len() -> integer\n" \
@@ -261,10 +264,10 @@
 	"for large strings in multiple smaller chunks."
 
 #define automaton_values_doc \
-	"values([prefix, [wildcard, [how]]])\n" \
+	"values([pattern, [how]])\n" \
 	"\n" \
 	"Return an iterator on values associated with each keys. Keys\n" \
-	"are matched optionally to the prefix using the same logic\n" \
+	"are matched optionally to the pattern using the same logic\n" \
 	"and arguments as in the keys() method."
 
 #define module_doc \

--- a/src/pyahocorasick.c
+++ b/src/pyahocorasick.c
@@ -122,9 +122,8 @@ init_function(void) {
     add_enum_const(KEY_STRING);
     add_enum_const(KEY_SEQUENCE);
 
-    add_enum_const(MATCH_EXACT_LENGTH);
-    add_enum_const(MATCH_AT_MOST_PREFIX);
-    add_enum_const(MATCH_AT_LEAST_PREFIX);
+    add_enum_const(MATCH_PREFIX);
+    add_enum_const(MATCH_WHOLE);
 #undef add_enum_const
 
 #ifdef AHOCORASICK_UNICODE

--- a/tests/memdump_check.py
+++ b/tests/memdump_check.py
@@ -61,7 +61,8 @@ class Application(object):
 
                 try:
                     key = int(oldaddr, 16)
-                    del self.memory[oldaddr]
+                    if key != 0:
+                        del self.memory[oldaddr]
                 except ValueError:
                     pass
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -467,7 +467,7 @@ class TestTrieIterators(TestTrieStorePyObjectsBase):
             A.add_word(conv(word), word)
 
         I = ["aXcd"]
-        L = [x for x in A.keys(conv("a?cd"), conv("?"))]
+        L = [x for x in A.keys(conv("a?cd"), ahocorasick.MATCH_WHOLE)]
         self.assertEqual(set(map(conv, I)), set(L))
 
     def test_items_with_valid_pattern2(self):
@@ -476,25 +476,97 @@ class TestTrieIterators(TestTrieStorePyObjectsBase):
         for word in words:
             A.add_word(conv(word), word)
 
-        L = [x for x in A.keys(conv("a?c??"), conv("?"), ahocorasick.MATCH_EXACT_LENGTH)]
+        L = [x for x in A.keys(conv("a?c??"), ahocorasick.MATCH_WHOLE)]
         I = ["abcde", "aXcde"]
         self.assertEqual(set(map(conv, I)), set(L))
 
-        L = [x for x in A.keys(conv("a?c??"), conv("?"), ahocorasick.MATCH_AT_MOST_PREFIX)]
-        I = ["aYc", "abcde", "aXcde"]
-        self.assertEqual(set(map(conv, I)), set(L))
-
-        L = [x for x in A.keys(conv("a?c??"), conv("?"), ahocorasick.MATCH_AT_LEAST_PREFIX)]
+        L = [x for x in A.keys(conv("a?c??*"), ahocorasick.MATCH_WHOLE)]
         I = ["abcde", "aXcde", "aZcdef"]
         self.assertEqual(set(map(conv, I)), set(L))
 
-    def test_items_wrong_wildcrard(self):
-        with self.assertRaisesRegex(ValueError, "Wildcard must be a single character.*"):
-            self.A.keys(conv("anything"), conv("??"))
+        L = [x for x in A.keys(conv("a?c??"))]
+        I = ["abcde", "aXcde", "aZcdef"]
+        self.assertEqual(set(map(conv, I)), set(L))
+
+    def test_items_with_valid_pattern3(self):
+        A = self.A
+        words = "ash ashley ash* ash? ash*ley*?* ash\\ley ash\\*ley".split()
+        for word in words:
+            A.add_word(conv(word), word)
+
+        L = [x for x in A.values(conv("a*"), ahocorasick.MATCH_WHOLE)]
+        I = words
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv("ash*"), ahocorasick.MATCH_WHOLE)]
+        I = words
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv("ash???"), ahocorasick.MATCH_WHOLE)]
+        I = ["ashley"]
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv("ash?"), ahocorasick.MATCH_WHOLE)]
+        I = ["ash*", "ash?"]
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv("ash?"))]
+        I = ["ashley", "ash*", "ash?", "ash*ley*?*", "ash\\ley", "ash\\*ley"]
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv("ash*ley"), ahocorasick.MATCH_WHOLE)]
+        I = ["ashley", "ash\\ley", "ash\\*ley"]
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv("ash***"), ahocorasick.MATCH_WHOLE)]
+        I = words
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv("*a******"), ahocorasick.MATCH_WHOLE)]
+        I = words
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv("*"), ahocorasick.MATCH_WHOLE)]
+        I = words
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv("ash*t"), ahocorasick.MATCH_WHOLE)]
+        I = []
+        self.assertEqual(set(I), set(L))
+
+    def test_items_with_valid_escaped_pattern(self):
+        A = self.A
+        words = "ash ashley ash* ash? ash*ley*?* ash\\ley ash\\*ley".split()
+        for word in words:
+            A.add_word(conv(word), word)
+
+        L = [x for x in A.values(conv(r"ash\\*"), ahocorasick.MATCH_WHOLE)]
+        I = ["ash\\ley", "ash\\*ley"]
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv(r"ash\*"), ahocorasick.MATCH_WHOLE)]
+        I = ["ash*"]
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv(r"ash\\\**"), ahocorasick.MATCH_WHOLE)]
+        I = ["ash\\*ley"]
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv(r"ash\\\*ley"), ahocorasick.MATCH_WHOLE)]
+        I = ["ash\\*ley"]
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv(r"ash\?"), ahocorasick.MATCH_WHOLE)]
+        I = ["ash?"]
+        self.assertEqual(set(I), set(L))
+
+        L = [x for x in A.values(conv(r"ash*\?\*"), ahocorasick.MATCH_WHOLE)]
+        I = ["ash*ley*?*"]
+        self.assertEqual(set(I), set(L))
 
     def test_items_wrong_match_enum(self):
-        with self.assertRaisesRegex(ValueError, "The optional how third argument must be one of"):
-            self.A.keys(conv("anything"), conv("?"), -42)
+        with self.assertRaisesRegex(ValueError, "The optional 'how' argument must be one of"):
+            self.A.keys(conv("anything"), -42)
 
 
 class TestTrieIteratorsInvalidate(TestTrieStorePyObjectsBase):


### PR DESCRIPTION
BREAKING CHANGE: This PR changes the signature and behavior of the `keys`, `values`, and `items` methods of the `Automaton` class to process the optional `pattern` parameter as a Unix shell glob-style pattern. 

Currently only the `'?'` (match any single character) and `'*'` (match zero or more characters) wildcards are supported (so no character classes nor ranges). The `'\'` character is reserved as the wildcard escape character (so any literal `'\'` in a `pattern` must itself be escaped as `'\\\\'` or `r'\\'`).

The optional `wildcard` parameter is gone. The values for the optional `how` parameter can be one of `MATCH_PREFIX` (default; prefix match on keys) and `MATCH_WHOLE` (full match on keys).
