### PR TITLE
Add mingw declarations

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -24,6 +24,8 @@
 #else
 #   if defined(__CYGWIN__)
 #        include "cygwin.h"
+#   elif defined(__MINGW32__)
+#        include "mingw.h"
 #   else
 #        include "posix.h"
 #   endif

--- a/src/mingw.h
+++ b/src/mingw.h
@@ -1,0 +1,17 @@
+/*
+    This is part of pyahocorasick Python module.
+    
+    MINGW declarations.
+
+    Author    : Wojciech Muła, wojciech_mula@poczta.onet.pl
+    WWW       : http://0x80.pl
+    License   : BSD-3-Clause (see LICENSE)
+*/
+
+#ifndef PYAHCORASICK_MINGW_H__
+#define PYAHCORASICK_MINGW_H__
+
+#define PY_OBJECT_HEAD_INIT PyVarObject_HEAD_INIT(NULL, 0)
+
+#endif
+


### PR DESCRIPTION
I added a mingw declarations file to support that platform. It was copied from the cygwin definitions. I appear to be able to compile, load, and use this library from msys2 with this change. `__MINGW32__` is defined for 64 bit targets as well as 32 bit. I only tested this on mingw64 through msys2, but I think this should work for the original mingw as well, though I'm not sure if people still use that.