### PR TITLE
Fix Integer Cast Order

### DIFF
--- a/src/custompickle/load/loadbuffer.c
+++ b/src/custompickle/load/loadbuffer.c
@@ -65,7 +65,7 @@ loadbuffer_init(LoadBuffer* input, CustompickleHeader* header, CustompickleFoote
         return 0;
     }
 
-    ret = fseek(input->file, -sizeof(CustompickleFooter), SEEK_END);
+    ret = fseek(input->file, -(long int)sizeof(CustompickleFooter), SEEK_END);
     if (UNLIKELY(ret < 0)) {
         PyErr_SetFromErrno(PyExc_IOError);
         return 0;


### PR DESCRIPTION
This PR fixes a compiler warning created by negating an unsigned integer before casting it to a signed integer. This is fixed by explicitly casting the unsized integer to a `long int`, the type it is implicitly casted to, before negating it.