### PR TITLE
Fix long iter again

### DIFF
--- a/src/AutomatonSearchIterLong.c
+++ b/src/AutomatonSearchIterLong.c
@@ -90,6 +90,7 @@ static PyObject*
 automaton_search_iter_long_next(PyObject* self) {
     PyObject* output;
     TrieNode* next;
+    TrieNode* next2;
 
     if (iter->version != iter->automaton->version) {
         PyErr_SetString(PyExc_ValueError, "underlaying automaton has changed, iterator is not valid anymore");
@@ -120,9 +121,17 @@ return_output:
                 iter->last_node  = next;
                 iter->last_index = iter->index;
             } else if (next->fail && next->fail != iter->automaton->root && next->fail->eow) {
-                iter->last_node  = next->fail;
-                iter->last_index = iter->index;
-                goto return_output;
+                // failover only if the next of next node exists
+                if (iter->index+1 >= iter->end) {
+                    next2 = NULL;
+                } else {
+                    next2 = trienode_get_next(next, iter->input.word[iter->index+1]);
+                }
+                if (!next2) {
+                    iter->last_node  = next->fail;
+                    iter->last_index = iter->index;
+                    goto return_output;
+                }
             }
 
             iter->state = next;

--- a/src/AutomatonSearchIterLong.c
+++ b/src/AutomatonSearchIterLong.c
@@ -90,6 +90,9 @@ static PyObject*
 automaton_search_iter_long_next(PyObject* self) {
     PyObject* output;
     TrieNode* next;
+    TrieNode* fail_node = NULL; //< the node to fail over
+    int fail_index = -1;        //< the index to fail over
+    uint8_t fail_flag = false;  //< whether this iteration is trigger by failover
 
     if (iter->version != iter->automaton->version) {
         PyErr_SetString(PyExc_ValueError, "underlaying automaton has changed, iterator is not valid anymore");
@@ -113,15 +116,24 @@ return_output:
 
     iter->index += 1;
     while (iter->index < iter->end) {
-        next = trienode_get_next(iter->state, iter->input.word[iter->index]);
+        if (fail_flag) {
+            // when failover start from fail node instead of next
+            next = fail_node->fail;
+            iter->index = fail_index;
+            fail_node = NULL;
+            fail_index = -1;
+            fail_flag = false;
+        } else {
+            next = trienode_get_next(iter->state, iter->input.word[iter->index]);
+        }
         if (next) {
             if (next->eow) {
                 // save the last node on the path
                 iter->last_node  = next;
                 iter->last_index = iter->index;
-            } else if (!iter->last_node && next->fail && next->fail != iter->automaton->root && next->fail->eow) {
-                iter->last_node = next->fail;
-                iter->last_index = iter->index;
+            } else if (!iter->last_node && !fail_node && next->fail && next->fail != iter->automaton->root && next->fail->eow) {
+                fail_node = next;
+                fail_index = iter->index;
             }
 
             iter->state = next;
@@ -130,6 +142,11 @@ return_output:
             if (iter->last_node) {
                 goto return_output;
             } else {
+                if (fail_node) {
+                  // failover
+                  fail_flag = true;
+                  continue;
+                }
                 while (true) {
                     iter->state = iter->state->fail;
                     if (iter->state == NULL) {

--- a/src/AutomatonSearchIterLong.c
+++ b/src/AutomatonSearchIterLong.c
@@ -90,7 +90,6 @@ static PyObject*
 automaton_search_iter_long_next(PyObject* self) {
     PyObject* output;
     TrieNode* next;
-    TrieNode* next2;
 
     if (iter->version != iter->automaton->version) {
         PyErr_SetString(PyExc_ValueError, "underlaying automaton has changed, iterator is not valid anymore");
@@ -120,18 +119,9 @@ return_output:
                 // save the last node on the path
                 iter->last_node  = next;
                 iter->last_index = iter->index;
-            } else if (next->fail && next->fail != iter->automaton->root && next->fail->eow) {
-                // failover only if the next of next node exists
-                if (iter->index+1 >= iter->end) {
-                    next2 = NULL;
-                } else {
-                    next2 = trienode_get_next(next, iter->input.word[iter->index+1]);
-                }
-                if (!next2) {
-                    iter->last_node  = next->fail;
-                    iter->last_index = iter->index;
-                    goto return_output;
-                }
+            } else if (!iter->last_node && next->fail && next->fail != iter->automaton->root && next->fail->eow) {
+                iter->last_node = next->fail;
+                iter->last_index = iter->index;
             }
 
             iter->state = next;

--- a/tests/test_issue_133.py
+++ b/tests/test_issue_133.py
@@ -37,6 +37,19 @@ def test_issue133_iter_long_2():
     assert res == expected
 
 
+def test_issue133_iter_long_3():
+    automaton = ahocorasick.Automaton()
+    for word in ["trimethoprim", "sulfamethoxazole", "meth"]:
+        converted = conv(word)
+        automaton.add_word(converted, word)
+    automaton.make_automaton()
+
+    res = list(automaton.iter_long(conv("sulfamethoxazole and trimethoprim")))
+
+    expected = [(15, "sulfamethoxazole"), (32, "trimethoprim")]
+    assert res == expected
+
+
 def test_issue133_iter_long_with_multibyte_characters():
     automaton = ahocorasick.Automaton()
     for word in ["知识产权", "国家知识产权局"]:

--- a/tests/test_issue_133.py
+++ b/tests/test_issue_133.py
@@ -61,6 +61,19 @@ def test_issue133_iter_long_4():
     expected = [(1, "is"), (6, "this")]
     assert res == expected
 
+def test_issue133_iter_long_5():
+    automaton = ahocorasick.Automaton()
+    for word in ["th", "this", "is this a dream?"]:
+        converted = conv(word)
+        automaton.add_word(converted, word)
+    automaton.make_automaton()
+
+    res = list(automaton.iter_long(conv("is this a test?")))
+
+    expected = [(6, "this")]
+    assert res == expected
+
+
 
 def test_issue133_iter_long_with_multibyte_characters():
     automaton = ahocorasick.Automaton()

--- a/tests/test_issue_133.py
+++ b/tests/test_issue_133.py
@@ -49,15 +49,27 @@ def test_issue133_iter_long_3():
     expected = [(15, "sulfamethoxazole"), (32, "trimethoprim")]
     assert res == expected
 
-
-def test_issue133_iter_long_with_multibyte_characters():
+def test_issue133_iter_long_4():
     automaton = ahocorasick.Automaton()
-    for word in ["知识产权", "国家知识产权局"]:
+    for word in ["is", "this", "is this a dream?"]:
         converted = conv(word)
         automaton.add_word(converted, word)
     automaton.make_automaton()
 
-    res = list(automaton.iter_long(conv("国家知识产权")))
+    res = list(automaton.iter_long(conv("is this a test?")))
+
+    expected = [(1, "is"), (6, "this")]
+    assert res == expected
+
+
+def test_issue133_iter_long_with_multibyte_characters():
+    automaton = ahocorasick.Automaton()
+    for word in ["知识产权", "国家知识产权局2"]:
+        converted = conv(word)
+        automaton.add_word(converted, word)
+    automaton.make_automaton()
+
+    res = list(automaton.iter_long(conv("国家知识产权局1")))
     if ahocorasick.unicode:
         expected = [(5, "知识产权")]
     else:


### PR DESCRIPTION
Fix #185 
The idea is to cache the first fail_node during iteration. Later if a last_node is found (meaning a match, surely longest), the cached fail_node is not used and discarded. If no match is found, instead of continuing, we rewind to the cached node to try shorter match that we missed earlier.