### PR TITLE
Remove Python 2 support code

### DIFF
--- a/src/Automaton.c
+++ b/src/Automaton.c
@@ -900,8 +900,7 @@ automaton_iter(PyObject* self, PyObject* args, PyObject* keywds) {
 
     if (object) {
         if (automaton->key_type == KEY_STRING) {
-#ifdef PY3K
-    #ifdef AHOCORASICK_UNICODE
+#ifdef AHOCORASICK_UNICODE
         if (F(PyUnicode_Check)(object)) {
             start   = 0;
             #if PY_MINOR_VERSION >= 3
@@ -914,22 +913,13 @@ automaton_iter(PyObject* self, PyObject* args, PyObject* keywds) {
             PyErr_SetString(PyExc_TypeError, "string required");
             return NULL;
         }
-    #else
+#else
         if (F(PyBytes_Check)(object)) {
             start   = 0;
             end     = PyBytes_GET_SIZE(object);
         }
         else {
             PyErr_SetString(PyExc_TypeError, "bytes required");
-            return NULL;
-        }
-    #endif
-#else
-        if (F(PyString_Check)(object)) {
-            start   = 0;
-            end     = PyString_GET_SIZE(object);
-        } else {
-            PyErr_SetString(PyExc_TypeError, "string required");
             return NULL;
         }
 #endif
@@ -984,8 +974,7 @@ automaton_iter_long(PyObject* self, PyObject* args) {
         return NULL;
 
     if (automaton->key_type == KEY_STRING) {
-#ifdef PY3K
-    #ifdef AHOCORASICK_UNICODE
+#ifdef AHOCORASICK_UNICODE
         if (F(PyUnicode_Check)(object)) {
             start   = 0;
             #if PY_MINOR_VERSION >= 3
@@ -998,22 +987,13 @@ automaton_iter_long(PyObject* self, PyObject* args) {
             PyErr_SetString(PyExc_TypeError, "string required");
             return NULL;
         }
-    #else
+#else
         if (F(PyBytes_Check)(object)) {
             start   = 0;
             end     = PyBytes_GET_SIZE(object);
         }
         else {
             PyErr_SetString(PyExc_TypeError, "bytes required");
-            return NULL;
-        }
-    #endif
-#else
-        if (F(PyString_Check)(object)) {
-            start   = 0;
-            end     = PyString_GET_SIZE(object);
-        } else {
-            PyErr_SetString(PyExc_TypeError, "string required");
             return NULL;
         }
 #endif

--- a/src/AutomatonItemsIter.c
+++ b/src/AutomatonItemsIter.c
@@ -251,14 +251,10 @@ automaton_items_iter_next(PyObject* self) {
                     switch (iter->automaton->store) {
                         case STORE_ANY:
                             return F(Py_BuildValue)(
-#ifdef PY3K
-    #ifdef AHOCORASICK_UNICODE
+#ifdef AHOCORASICK_UNICODE
                                 "(u#O)", /*key*/ iter->buffer + 1, depth,
-    #else
-                                "(y#O)", /*key*/ iter->buffer + 1, depth,
-    #endif
 #else
-                                "(s#O)", /*key*/ iter->char_buffer + 1, depth,
+                                "(y#O)", /*key*/ iter->buffer + 1, depth,
 #endif
                                 /*val*/ iter->state->output.object
                             );
@@ -266,14 +262,10 @@ automaton_items_iter_next(PyObject* self) {
                         case STORE_LENGTH:
                         case STORE_INTS:
                             return F(Py_BuildValue)(
-#ifdef PY3K
-    #ifdef AHOCORASICK_UNICODE
+#ifdef AHOCORASICK_UNICODE
                                 "(u#i)", /*key*/ iter->buffer + 1, depth,
-    #else
-                                "(y#i)", /*key*/ iter->buffer + 1, depth,
-    #endif
 #else
-                                "(s#i)", /*key*/ iter->char_buffer + 1, depth,
+                                "(y#i)", /*key*/ iter->buffer + 1, depth,
 #endif
                                 /*val*/ iter->state->output.integer
                             );

--- a/src/AutomatonItemsIter.c
+++ b/src/AutomatonItemsIter.c
@@ -221,10 +221,8 @@ automaton_items_iter_next(PyObject* self) {
 
             switch (iter->type) {
                 case ITER_KEYS:
-#if defined PEP393_UNICODE
+#if defined AHOCORASICK_UNICODE
                     return F(PyUnicode_FromKindAndData)(PyUnicode_4BYTE_KIND, (void*)(iter->buffer + 1), depth);
-#elif defined AHOCORASICK_UNICODE
-                    return PyUnicode_FromUnicode((Py_UNICODE*)(iter->buffer + 1), depth);
 #else
                     return PyBytes_FromStringAndSize(iter->char_buffer + 1, depth);
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -31,19 +31,11 @@
 #   endif
 #endif
 
-#if PY_MAJOR_VERSION >= 3
-    #define PY3K
-    #if PY_MINOR_VERSION >= 3 || PY_MAJOR_VERSION > 3
-    #define PEP393
-    #ifdef AHOCORASICK_UNICODE
-        #define PEP393_UNICODE
-    #endif
-    #endif
-#else
-    #ifdef AHOCORASICK_UNICODE
-        #warning "No support for unicode in version for Python2"
-    #endif
-    #undef AHOCORASICK_UNICODE
+#if PY_MINOR_VERSION >= 3 || PY_MAJOR_VERSION > 3
+#define PEP393
+#ifdef AHOCORASICK_UNICODE
+    #define PEP393_UNICODE
+#endif
 #endif
 
 // setup supported character set
@@ -86,7 +78,7 @@
 #   define  ASSERT(expr)
 #endif
 
-#if defined(PYCALLS_INJECT_FAULTS) && defined(PY3K)
+#if defined(PYCALLS_INJECT_FAULTS)
 #   include "pycallfault/pycallfault.h"
 #else
 #   define F(name) name

--- a/src/common.h
+++ b/src/common.h
@@ -31,26 +31,12 @@
 #   endif
 #endif
 
-#if PY_MINOR_VERSION >= 3 || PY_MAJOR_VERSION > 3
-#define PEP393
-#ifdef AHOCORASICK_UNICODE
-    #define PEP393_UNICODE
-#endif
-#endif
-
 // setup supported character set
 #ifdef AHOCORASICK_UNICODE
-#       if defined PEP393_UNICODE || defined Py_UNICODE_WIDE
-        // Either Python uses UCS-4 or we don't know what Python uses,
-        // but we use UCS-4
-#       define TRIE_LETTER_TYPE uint32_t
-#       define TRIE_LETTER_SIZE 4
-#   else
-        // Python use UCS-2
-#       define TRIE_LETTER_TYPE uint16_t
-#       define TRIE_LETTER_SIZE 2
-#       define VARIABLE_LEN_CHARCODES 1
-#   endif
+    // Either Python uses UCS-4 or we don't know what Python uses,
+    // but we use UCS-4
+#   define TRIE_LETTER_TYPE uint32_t
+#   define TRIE_LETTER_SIZE 4
 #else
     // only bytes are supported
 #   define TRIE_LETTER_TYPE uint16_t

--- a/src/custompickle/pyhelpers.c
+++ b/src/custompickle/pyhelpers.c
@@ -22,17 +22,10 @@ automaton_save_load_parse_args(KeysStore store, PyObject* args, SaveLoadParamete
         return false;
     }
 
-#if defined(PY3K)
     if (UNLIKELY(!F(PyUnicode_Check)(string))) {
         PyErr_SetString(PyExc_TypeError, "the first argument must be a string");
         return false;
     }
-#else
-    if (UNLIKELY(!F(PyString_Check)(string))) {
-        PyErr_SetString(PyExc_TypeError, "the first argument must be a string");
-        return false;
-    }
-#endif
 
     if (store == STORE_ANY) {
         result->callback = F(PyTuple_GetItem)(args, 1);
@@ -46,12 +39,7 @@ automaton_save_load_parse_args(KeysStore store, PyObject* args, SaveLoadParamete
         }
     }
 
-#if defined(PY3K)
     result->path = F(PyUnicode_AsUTF8String)(string);
-#else
-    result->path = string;
-    Py_INCREF(string);
-#endif
     if (UNLIKELY(result->path == NULL)) {
         return false;
     }

--- a/src/pyahocorasick.c
+++ b/src/pyahocorasick.c
@@ -45,7 +45,6 @@ ahocorasick_module_methods[] = {
 };
 
 
-#ifdef PY3K
 static
 PyModuleDef ahocorasick_module = {
     PyModuleDef_HEAD_INIT,
@@ -54,18 +53,9 @@ PyModuleDef ahocorasick_module = {
     -1,
     ahocorasick_module_methods
 };
-#endif
-
-#ifdef PY3K
-#define init_function PyInit_ahocorasick
-#define init_return(value) return (value)
-#else
-#define init_function initahocorasick
-#define init_return(unused) return
-#endif
 
 PyMODINIT_FUNC
-init_function(void) {
+PyInit_ahocorasick(void) {
     PyObject* module;
 
 #ifdef MEMORY_DEBUG
@@ -94,18 +84,14 @@ init_function(void) {
 
     automaton_type.tp_as_sequence = &automaton_as_sequence;
 
-#ifdef PY3K
     module = PyModule_Create(&ahocorasick_module);
-#else
-    module = Py_InitModule3("ahocorasick", ahocorasick_module_methods, module_doc);
-#endif
     if (module == NULL)
-        init_return(NULL);
+        return NULL;
 
 
     if (PyType_Ready(&automaton_type) < 0) {
         Py_DECREF(module);
-        init_return(NULL);
+        return NULL;
     }
     else
         PyModule_AddObject(module, "Automaton", (PyObject*)&automaton_type);
@@ -133,5 +119,5 @@ init_function(void) {
     PyModule_AddIntConstant(module, "unicode", 0);
 #endif
 
-    init_return(module);
+    return module;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -125,12 +125,7 @@ void memory_safefree(void* ptr) {
 }
 
 
-#if !defined(PY3K) || !defined(AHOCORASICK_UNICODE)
-//  define when pymod_get_string makes a copy of string
-#   define INPUT_KEEPS_COPY
-#endif
-
-#if defined INPUT_KEEPS_COPY
+#ifndef AHOCORASICK_UNICODE
 #    define maybe_free(flag, word) memory_free(word);
 #    define maybe_decref(flag, ref)
 #elif defined PEP393_UNICODE
@@ -145,7 +140,7 @@ void memory_safefree(void* ptr) {
 static PyObject*
 pymod_get_string(PyObject* obj, TRIE_LETTER_TYPE** word, Py_ssize_t* wordlen, bool* is_copy) {
 
-#ifdef INPUT_KEEPS_COPY
+#ifndef AHOCORASICK_UNICODE
     Py_ssize_t i;
     char* bytes;
 #endif
@@ -172,7 +167,7 @@ pymod_get_string(PyObject* obj, TRIE_LETTER_TYPE** word, Py_ssize_t* wordlen, bo
     PyErr_SetString(PyExc_TypeError, "string expected");
     return NULL;
     }
-#elif defined PY3K
+#else
 #   ifdef AHOCORASICK_UNICODE
         if (F(PyUnicode_Check)(obj)) {
             *word = (TRIE_LETTER_TYPE*)(PyUnicode_AS_UNICODE(obj));
@@ -185,9 +180,6 @@ pymod_get_string(PyObject* obj, TRIE_LETTER_TYPE** word, Py_ssize_t* wordlen, bo
             return NULL;
         }
 #   else
-#       ifndef INPUT_KEEPS_COPY
-#           error "defines inconsistency"
-#       endif
         if (F(PyBytes_Check)(obj)) {
             *wordlen = PyBytes_GET_SIZE(obj);
             *word    = (TRIE_LETTER_TYPE*)memory_alloc(*wordlen * TRIE_LETTER_SIZE);
@@ -208,30 +200,6 @@ pymod_get_string(PyObject* obj, TRIE_LETTER_TYPE** word, Py_ssize_t* wordlen, bo
             return NULL;
         }
 #   endif
-#else // PY_MAJOR_VERSION == 3
-#       ifndef INPUT_KEEPS_COPY
-#           error "defines inconsistency"
-#       endif
-    if (F(PyString_Check)(obj)) {
-        *wordlen = PyString_GET_SIZE(obj);
-        *word    = (TRIE_LETTER_TYPE*)memory_alloc(*wordlen * TRIE_LETTER_SIZE);
-        if (*word == NULL) {
-            PyErr_NoMemory();
-            return NULL;
-        }
-
-
-        bytes = PyString_AS_STRING(obj);
-        for (i=0; i < *wordlen; i++) {
-            (*word)[i] = bytes[i];
-        };
-
-        Py_INCREF(obj);
-        return obj;
-    } else {
-        PyErr_SetString(PyExc_TypeError, "string required");
-        return NULL;
-    }
 #endif
 }
 


### PR DESCRIPTION
Python 2 was dropped in #166 / the 2.0.0 release, so non-`PY3K` code is clutter that can be dropped. Python 3.6 and 3.7 were dropped in the 2.1.0 release, so code for Python 3 < 3.3 can also be removed.