### PR TITLE
Fix use of bool keyword in C23 (fixes #199)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -16,6 +16,7 @@
 #include <structmember.h>   // PyMemberDef
 
 #include <iso646.h>
+#include <stdbool.h>
 
 #define DEBUG
 
@@ -91,9 +92,5 @@
 #else
 #   define F(name) name
 #endif
-
-typedef char    bool;
-#define true 1
-#define false 0
 
 #endif


### PR DESCRIPTION
Instead of custom typedef and defines, use stdbool.h which includes the required feature testing.