### PR TITLE
Update CHANGELOG for release v2.2.0

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -36,7 +36,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [macos-13, windows-2022]
+                os: [macos-latest, windows-latest]
                 arch: [auto64]
                 build: ["cp{39,310,311,312,313}-*"]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,14 +2,23 @@
 Changelog
 =============
 
-2.2.0 (2024-10-21)
+2.2.0 (2025-06-18)
 --------------------------------------------------
 
 - Drop support for Python 3.8. Use older version for pre-built wheels.
   Note that it may work on these older versions, we are just no longer supporting
   and testing these Python versions, as this is end of life
 
-- Add support for Python 3.13
+- Add support for Python 3.13 and update CI scripts
+  https://github.com/WojciechMula/pyahocorasick/pull/194
+
+- Supports build pyahocorasick with GCC 15.0.1
+  https://github.com/WojciechMula/pyahocorasick/pull/201
+
+- Fix `iter-long` method
+  https://github.com/WojciechMula/pyahocorasick/pull/187
+  https://github.com/WojciechMula/pyahocorasick/pull/196
+
 
 2.1.0 (2024-03-21)
 --------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ benchmark: etc/benchmarks/benchmark.py build
 	python3 $^
 
 valgrind:
-	python -c "import sys;print(sys.version)"
+	venv/bin/python3 -c "import sys;print(sys.version)"
 	valgrind --leak-check=full --track-origins=yes --log-file=valgrind.log venv/bin/pytest -vvs
 
 clean:


### PR DESCRIPTION
@pombredanne We are ready for a release after this, wheels building allright at https://github.com/WojciechMula/pyahocorasick/actions/runs/15717095798 and `twine check` is all green too. Please upload to pypi after tag push.
```
(venv)
nexB/write_access/pyahocorasick  update-changelog ✔                                                                                                                                       1m
▶ ls -la dist
total 1896
drwxrwxr-x  2 ayansinha ayansinha   4096 Jun 18 01:52 .
drwxrwxr-x 13 ayansinha ayansinha   4096 Jun 18 01:43 ..
-rw-r--r--  1 ayansinha ayansinha  58159 Jun 17 20:16 pyahocorasick-2.2.0-cp310-cp310-macosx_10_9_universal2.whl
-rw-r--r--  1 ayansinha ayansinha  33240 Jun 17 20:16 pyahocorasick-2.2.0-cp310-cp310-macosx_11_0_arm64.whl
-rw-r--r--  1 ayansinha ayansinha 106573 Jun 17 20:16 pyahocorasick-2.2.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl
-rw-r--r--  1 ayansinha ayansinha 113493 Jun 17 20:16 pyahocorasick-2.2.0-cp310-cp310-musllinux_1_2_x86_64.whl
-rw-rw-rw-  1 ayansinha ayansinha  34992 Jun 17 20:17 pyahocorasick-2.2.0-cp310-cp310-win_amd64.whl
-rw-r--r--  1 ayansinha ayansinha  58130 Jun 17 20:17 pyahocorasick-2.2.0-cp311-cp311-macosx_10_9_universal2.whl
-rw-r--r--  1 ayansinha ayansinha  33242 Jun 17 20:16 pyahocorasick-2.2.0-cp311-cp311-macosx_11_0_arm64.whl
-rw-r--r--  1 ayansinha ayansinha 113941 Jun 17 20:16 pyahocorasick-2.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r--  1 ayansinha ayansinha 116381 Jun 17 20:17 pyahocorasick-2.2.0-cp311-cp311-musllinux_1_2_x86_64.whl
-rw-rw-rw-  1 ayansinha ayansinha  34983 Jun 17 20:18 pyahocorasick-2.2.0-cp311-cp311-win_amd64.whl
-rw-r--r--  1 ayansinha ayansinha  58174 Jun 17 20:17 pyahocorasick-2.2.0-cp312-cp312-macosx_10_13_universal2.whl
-rw-r--r--  1 ayansinha ayansinha  33285 Jun 17 20:16 pyahocorasick-2.2.0-cp312-cp312-macosx_11_0_arm64.whl
-rw-r--r--  1 ayansinha ayansinha 114871 Jun 17 20:16 pyahocorasick-2.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r--  1 ayansinha ayansinha 117872 Jun 17 20:17 pyahocorasick-2.2.0-cp312-cp312-musllinux_1_2_x86_64.whl
-rw-rw-rw-  1 ayansinha ayansinha  35030 Jun 17 20:19 pyahocorasick-2.2.0-cp312-cp312-win_amd64.whl
-rw-r--r--  1 ayansinha ayansinha  58179 Jun 17 20:17 pyahocorasick-2.2.0-cp313-cp313-macosx_10_13_universal2.whl
-rw-r--r--  1 ayansinha ayansinha  33289 Jun 17 20:16 pyahocorasick-2.2.0-cp313-cp313-macosx_11_0_arm64.whl
-rw-r--r--  1 ayansinha ayansinha 114812 Jun 17 20:16 pyahocorasick-2.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-rw-r--r--  1 ayansinha ayansinha 117865 Jun 17 20:17 pyahocorasick-2.2.0-cp313-cp313-musllinux_1_2_x86_64.whl
-rw-rw-rw-  1 ayansinha ayansinha  35021 Jun 17 20:19 pyahocorasick-2.2.0-cp313-cp313-win_amd64.whl
-rw-r--r--  1 ayansinha ayansinha  58172 Jun 17 20:16 pyahocorasick-2.2.0-cp39-cp39-macosx_10_9_universal2.whl
-rw-r--r--  1 ayansinha ayansinha  33253 Jun 17 20:16 pyahocorasick-2.2.0-cp39-cp39-macosx_11_0_arm64.whl
-rw-r--r--  1 ayansinha ayansinha  98690 Jun 17 20:16 pyahocorasick-2.2.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl
-rw-r--r--  1 ayansinha ayansinha 113088 Jun 17 20:16 pyahocorasick-2.2.0-cp39-cp39-musllinux_1_2_x86_64.whl
-rw-rw-rw-  1 ayansinha ayansinha  35037 Jun 17 20:16 pyahocorasick-2.2.0-cp39-cp39-win_amd64.whl
-rw-r--r--  1 ayansinha ayansinha 103902 Jun 17 20:15 pyahocorasick-2.2.0.tar.gz
(venv)
nexB/write_access/pyahocorasick  update-changelog ✔                                                                                                                                       7m
▶ twine check dist/*
Checking dist/pyahocorasick-2.2.0-cp310-cp310-macosx_10_9_universal2.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp310-cp310-macosx_11_0_arm64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp310-cp310-musllinux_1_2_x86_64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp310-cp310-win_amd64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp311-cp311-macosx_10_9_universal2.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp311-cp311-macosx_11_0_arm64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp311-cp311-musllinux_1_2_x86_64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp311-cp311-win_amd64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp312-cp312-macosx_10_13_universal2.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp312-cp312-macosx_11_0_arm64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp312-cp312-musllinux_1_2_x86_64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp312-cp312-win_amd64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp313-cp313-macosx_10_13_universal2.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp313-cp313-macosx_11_0_arm64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp313-cp313-musllinux_1_2_x86_64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp313-cp313-win_amd64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp39-cp39-macosx_10_9_universal2.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp39-cp39-macosx_11_0_arm64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp39-cp39-musllinux_1_2_x86_64.whl: PASSED
Checking dist/pyahocorasick-2.2.0-cp39-cp39-win_amd64.whl: PASSED
Checking dist/pyahocorasick-2.2.0.tar.gz: PASSED
(venv)
nexB/write_access/pyahocorasick  update-changelog ✔ 
```