### PR TITLE
Bump version to 2.3.0 with python 3.14 support

### DIFF
--- a/.github/workflows/extensive-tests.yml
+++ b/.github/workflows/extensive-tests.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+                python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
                 include:
                     - os: ubuntu-latest
                       test: make test

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,152 @@
+name: Create library release archives, create a GH release and publish PyPI wheel and sdist on tag in main branch
+
+
+# This is executed automatically on a tag in the main branch
+
+# Summary of the steps:
+# - build wheels and sdist
+# - upload wheels and sdist to PyPI
+# - create gh-release and upload wheels and dists there
+# TODO: smoke test wheels and sdist
+# TODO: add changelog to release text body
+
+# WARNING: this is designed only for packages building as pure Python wheels
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-wheels:
+      name: Build unicode wheels ${{ matrix.type }} ${{ matrix.arch }} on ${{ matrix.os }}
+      runs-on: ${{ matrix.os }}
+      defaults:
+        run:
+          shell: bash
+      strategy:
+          fail-fast: false
+          matrix:
+              os: [macos-latest, windows-latest]
+              arch: [auto64]
+              build: ["cp{310,311,312,313,314}-*"]
+
+              include:
+                  - os: ubuntu-latest
+                    arch: auto64
+                    type: manylinux2014
+                    build: "cp{310,311,312,313,314}-*"
+                    CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+
+                  - os: macos-latest
+                    arch: universal2
+                    build: "cp{310,311,312,313,314}-*"
+
+                  - os: windows-latest
+                    arch: auto64
+                    build: "cp{310,311,312,313,314}-*"
+
+      steps:
+          - uses: actions/checkout@v4
+
+          - name: Build wheels and run tests
+            uses: pypa/cibuildwheel@v3.2.1
+            env:
+                CIBW_BUILD: ${{ matrix.build }}
+                CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}
+                CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.CIBW_MANYLINUX_X86_64_IMAGE }}
+                CIBW_ARCHS: ${{ matrix.arch }}
+                CIBW_TEST_REQUIRES: pytest
+                CIBW_TEST_COMMAND: pytest -vvs {project}/tests
+
+          - name: Collect built wheels
+            uses: actions/upload-artifact@v4
+            with:
+                name: pyahocorasick-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+                path: ./wheelhouse/*.whl
+
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-24.04
+
+    steps:
+        - uses: actions/checkout@v4
+
+        - name: Checkout and install reqs
+          run: |
+              pip install --upgrade --user build twine pkginfo packaging pip setuptools cython
+
+        - name: Build sdist
+          run: |
+              python setup.py sdist
+              twine check dist/*
+
+        - name: Collect built sdist
+          uses: actions/upload-artifact@v4
+          with:
+              name: pyahocorasick-sdist
+              path: dist/*.tar.gz
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [build-sdist, build-wheels]
+    steps:
+      - name: Merge created wheels and sdist in a single zip
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: pyahocorasick-build
+          pattern: pyahocorasick-*
+
+  check-dist:
+    name: Check distributions are PyPi-correct
+    needs: merge
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: pyahocorasick-build
+      - run: find . -ls
+      - run: pipx run twine check --strict pyahocorasick-build/*/*
+
+  create-gh-release:
+    name: Create GH release
+    needs:
+      - check-dist
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Download builds
+        uses: actions/download-artifact@v4
+        with:
+          name: pyahocorasick-build
+          path: pyahocorasick-build
+
+      - name: Create GH release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: pyahocorasick-build/*
+
+  create-pypi-release:
+    name: Create PyPI release
+    needs:
+      - create-gh-release
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download builds
+        uses: actions/download-artifact@v4
+        with:
+          name: pyahocorasick-build
+          path: dist/
+
+      - name: Mock PyPI upload
+        run: |
+          ls -al dist
+
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -57,8 +57,6 @@ jobs:
                 CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}
                 CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.CIBW_MANYLINUX_X86_64_IMAGE }}
                 CIBW_ARCHS: ${{ matrix.arch }}
-                CIBW_TEST_REQUIRES: pytest
-                CIBW_TEST_COMMAND: pytest -vvs {project}/tests
 
           - name: Collect built wheels
             uses: actions/upload-artifact@v4

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -74,27 +74,6 @@ jobs:
                   name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
                   path: ./wheelhouse/*.whl
 
-    build_sdist:
-      name: Build source distribution
-      runs-on: ubuntu-24.04
-
-      steps:
-          - uses: actions/checkout@v4
-
-          - name: Checkout and install reqs
-            run: |
-                pip install --upgrade --user build twine packaging pip setuptools
-
-          - name: Build sdist
-            run: |
-                python setup.py sdist
-                twine check dist/*
-
-          - name: Collect built sdist
-            uses: actions/upload-artifact@v4
-            with:
-                path: dist/*.tar.gz
-
     test_on_many_oses:
         name: build ${{ matrix.build_type }} - Run tests ${{ matrix.python }} on ${{ matrix.os }} 
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -38,40 +38,28 @@ jobs:
             matrix:
                 os: [macos-latest, windows-latest]
                 arch: [auto64]
-                build: ["cp{39,310,311,312,313}-*"]
+                build: ["cp{310,311,312,313,314}-*"]
 
                 include:
                     - os: ubuntu-latest
                       arch: auto64
-                      type: manylinux1
-                      build: "cp39-*"
-                      CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
-
-                    - os: ubuntu-latest
-                      arch: auto64
-                      type: manylinux2010
-                      build: "cp310-*"
-                      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
-
-                    - os: ubuntu-latest
-                      arch: auto64
                       type: manylinux2014
-                      build: "cp{311,312,313}-*"
+                      build: "cp{310,311,312,313,314}-*"
                       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
                     - os: macos-latest
                       arch: universal2
-                      build: "cp{39,310,311,312,313}-*"
-                 
+                      build: "cp{310,311,312,313,314}-*"
+
                     - os: windows-latest
                       arch: auto64
-                      build: "cp{39,310,311,312,313}-*"
+                      build: "cp{310,311,312,313,314}-*"
 
         steps:
             - uses: actions/checkout@v4
 
             - name: Build wheels and run tests
-              uses: pypa/cibuildwheel@v2.23.3
+              uses: pypa/cibuildwheel@v3.2.1
               env:
                   CIBW_BUILD: ${{ matrix.build }}
                   CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}
@@ -79,8 +67,6 @@ jobs:
                   CIBW_ARCHS: ${{ matrix.arch }}
                   CIBW_TEST_REQUIRES: pytest
                   CIBW_TEST_COMMAND: pytest -vvs {project}/tests
-                  # Skip PyPy wheels
-                  CIBW_SKIP: "pp*"
 
             - name: Collect built wheels
               uses: actions/upload-artifact@v4
@@ -120,7 +106,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, windows-2022, windows-2025]
-                python: ["3.9", "3.10", "3.11", "3.12", "3.13.3"]
+                python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
                 build_type: ["AHOCORASICK_UNICODE", "AHOCORASICK_BYTES"]
 
         steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 Changelog
 =============
 
+2.3.0 (2025-10-30)
+--------------------------------------------------
+
+- Drop support for Python 3.9. Use older version for pre-built wheels.
+  Note that it may work on these older versions, we are just no longer supporting
+  and testing these Python versions, as this is end of life
+
+- Add support for Python 3.14 and update CI & release scripts
+  https://github.com/WojciechMula/pyahocorasick/pull/194
+
+
 2.2.0 (2025-06-18)
 --------------------------------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 =============
 
-2.3.0 (2025-10-30)
+2.3.0 (2025-11-24)
 --------------------------------------------------
 
 - Drop support for Python 3.9. Use older version for pre-built wheels.

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ module = Extension(
 
 setup(
     name="pyahocorasick",
-    version="2.2.0",
+    version="2.3.0",
     ext_modules=[module],
 
     description=(
@@ -124,5 +124,5 @@ setup(
     extras_require={
         "testing": ["pytest", "twine", "setuptools", "wheel", ],
     },
-    python_requires=">=3.9",
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
This PR bumps version to 2.3.0 and:
- drops support for Python 3.9 which is end-of-life
- adds support for Python 3.14. 

- All release testing passes at https://github.com/AyanSinhaMahapatra/pyahocorasick/releases/tag/v2.3.0rc2 with required wheels.

- Also added a release script at https://github.com/WojciechMula/pyahocorasick/blob/support-py314/.github/workflows/pypi-release.yml to publish to pypi with trusted publishing. https://docs.pypi.org/trusted-publishers/ 