### PR TITLE
Test linux arm support

### DIFF
--- a/.github/workflows/extensive-tests.yml
+++ b/.github/workflows/extensive-tests.yml
@@ -3,6 +3,7 @@ name: Run extensive tests Linux and select supported Pythons
 
 on: [workflow_dispatch]
 
+permissions: {}
 jobs:
     extensive_tests:
         name: Run test ${{ matrix.test }} on ${{ matrix.os }} and Python ${{ matrix.python }}
@@ -40,13 +41,15 @@ jobs:
                       test: ./runtest.sh valgrind
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+              with:
+                persist-credentials: false
 
             - name: Setup
               run: sudo apt-get install -y gcovr valgrind
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
               with:
                 python-version: "${{ matrix.python }}"
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -18,6 +18,7 @@ on:
     tags:
       - "v*.*.*"
 
+permissions: {}
 jobs:
   build-wheels:
       name: Build unicode wheels ${{ matrix.type }} ${{ matrix.arch }} on ${{ matrix.os }}
@@ -39,6 +40,11 @@ jobs:
                     build: "cp{310,311,312,313,314}-*"
                     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
+                  - os: ubuntu-24.04-arm
+                    arch: aarch64
+                    build: "cp{310,311,312,313,314}-*"
+                    CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+
                   - os: macos-latest
                     arch: universal2
                     build: "cp{310,311,312,313,314}-*"
@@ -48,18 +54,20 @@ jobs:
                     build: "cp{310,311,312,313,314}-*"
 
       steps:
-          - uses: actions/checkout@v4
+          - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+            with:
+              persist-credentials: false
 
           - name: Build wheels and run tests
-            uses: pypa/cibuildwheel@v3.2.1
+            uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084
             env:
                 CIBW_BUILD: ${{ matrix.build }}
-                CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}
                 CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.CIBW_MANYLINUX_X86_64_IMAGE }}
+                CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.CIBW_MANYLINUX_AARCH64_IMAGE }}
                 CIBW_ARCHS: ${{ matrix.arch }}
 
           - name: Collect built wheels
-            uses: actions/upload-artifact@v4
+            uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
             with:
                 name: pyahocorasick-wheels-${{ matrix.os }}-${{ strategy.job-index }}
                 path: ./wheelhouse/*.whl
@@ -69,7 +77,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+          with:
+            persist-credentials: false
 
         - name: Checkout and install reqs
           run: |
@@ -81,7 +91,7 @@ jobs:
               twine check dist/*
 
         - name: Collect built sdist
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
           with:
               name: pyahocorasick-sdist
               path: dist/*.tar.gz
@@ -91,7 +101,7 @@ jobs:
     needs: [build-sdist, build-wheels]
     steps:
       - name: Merge created wheels and sdist in a single zip
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: pyahocorasick-build
           pattern: pyahocorasick-*
@@ -101,7 +111,7 @@ jobs:
     needs: merge
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           path: pyahocorasick-build
       - run: find . -ls
@@ -112,16 +122,18 @@ jobs:
     needs:
       - check-dist
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write 
 
     steps:
       - name: Download builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: pyahocorasick-build
           path: pyahocorasick-build
 
       - name: Create GH release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           draft: true
           files: pyahocorasick-build/*
@@ -136,7 +148,7 @@ jobs:
 
     steps:
       - name: Download builds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: pyahocorasick-build
           path: dist/
@@ -147,4 +159,4 @@ jobs:
 
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -26,6 +26,7 @@ name: Run tests and build wheel and sdist on all supported OS and Python
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions: {}
 jobs:
     build_wheels:
         name: Build unicode wheels ${{ matrix.type }} ${{ matrix.arch }} on ${{ matrix.os }}
@@ -47,6 +48,11 @@ jobs:
                       build: "cp{310,311,312,313,314}-*"
                       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
+                    - os: ubuntu-24.04-arm
+                      arch: aarch64
+                      build: "cp{310,311,312,313,314}-*"
+                      CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+
                     - os: macos-latest
                       arch: universal2
                       build: "cp{310,311,312,313,314}-*"
@@ -56,20 +62,22 @@ jobs:
                       build: "cp{310,311,312,313,314}-*"
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+              with:
+                persist-credentials: false
 
             - name: Build wheels and run tests
-              uses: pypa/cibuildwheel@v3.2.1
+              uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084
               env:
                   CIBW_BUILD: ${{ matrix.build }}
-                  CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.CIBW_MANYLINUX_I686_IMAGE }}
                   CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.CIBW_MANYLINUX_X86_64_IMAGE }}
+                  CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.CIBW_MANYLINUX_AARCH64_IMAGE }}
                   CIBW_ARCHS: ${{ matrix.arch }}
                   CIBW_TEST_REQUIRES: pytest
                   CIBW_TEST_COMMAND: pytest -vvs {project}/tests
 
             - name: Collect built wheels
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
               with:
                   name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
                   path: ./wheelhouse/*.whl
@@ -84,17 +92,19 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, windows-2022, windows-2025]
+                os: [ubuntu-22.04, ubuntu-24.04, ubuntu-22.04-arm, ubuntu-24.04-arm, macos-14, macos-15, macos-15-intel, windows-2022, windows-2025]
                 python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
                 build_type: ["AHOCORASICK_UNICODE", "AHOCORASICK_BYTES"]
 
         steps:
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
               with:
                 python-version: "${{ matrix.python }}"
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+              with:
+                persist-credentials: false
 
             - name: Build, install and test
               run: >


### PR DESCRIPTION
See wheels being built properly at: https://github.com/WojciechMula/pyahocorasick/actions/runs/25002277555

This PR also updates github actions to pin dependencies and fixes issues detected by [zizmor](https://github.com/zizmorcore/zizmor).

Thanks also to:
* https://github.com/WojciechMula/pyahocorasick/pull/215 by @wilko77
* https://github.com/kkilchrist/pyahocorasick/commit/2830761949958ef1d0478d61a3d337441396c50a by @kkilchrist
for looking into this, I did this a tiny bit differently more in sync with how we had all the other wheel builds. Just having the arch and the image specific env was enough.

I also added some other updates to make the release more secure.