### PR TITLE
Fix reference leaks in Automaton pickling (leaked whole dump per pickle.dumps)

### DIFF
--- a/src/Automaton_pickle.c
+++ b/src/Automaton_pickle.c
@@ -261,16 +261,16 @@ automaton___reduce__(PyObject* self, PyObject* args) {
         data.values
     );
 
-    if (data.values == Py_None) {
-        data.values = NULL;
-    }
-
     if (UNLIKELY(tuple == NULL)) {
         goto exception;
     }
 
     // revert all changes
     trie_traverse(automaton->root, pickle_dump_undo_replace, NULL);
+
+    // Py_BuildValue's "O" format took its own references to bytes_list and
+    // values; release ours, otherwise every pickle leaks the whole dump.
+    pickle_data__cleanup(&data);
 
     return tuple;
 

--- a/src/pickle/pickle_data.c
+++ b/src/pickle/pickle_data.c
@@ -44,6 +44,10 @@ pickle_data__add_next_buffer(PickleData* data) {
 		return false;
 	}
 
+	// PyList_Append took its own reference; drop ours, otherwise every
+	// chunk buffer leaks. The list keeps the object alive.
+	Py_DECREF(bytes);
+
 	raw = PyBytes_AS_STRING(bytes);
 
 	data->count 	= (Py_ssize_t*)raw;


### PR DESCRIPTION
Fixes #219.

Two missing `Py_DECREF`s leaked approximately the full serialized size of the automaton on every successful `pickle.dumps()` (~1.7 MiB per call for a 3000-word automaton; see the issue for a standalone repro).

**`src/pickle/pickle_data.c` — `pickle_data__add_next_buffer()`**
`PyList_Append()` takes its own reference to the chunk; the reference owned after `PyBytes_FromStringAndSize()` was only released on the append-failure path. Now it is also released after a successful append — the list keeps the chunk alive. This was the bulk of the leak (the chunk buffers hold the entire node dump).

**`src/Automaton_pickle.c` — `automaton___reduce__()`**
`Py_BuildValue` with the `"O"` format takes new references to `bytes_list` and `values`, but the success path returned without releasing the function's own references (`pickle_data__cleanup()` was only reachable via the error label). Now cleanup runs on the success path too. The `data.values = NULL` special-case for `Py_None` is gone: the owned `Py_None` reference is released by cleanup like any other value.

Verification:
- Repro loop from the issue: RSS flat at 24 MiB after 600 dumps (previously 1020 MiB and climbing linearly).
- Round-trip `dumps`/`loads` produces identical `iter()` results, including the chunked multi-buffer path (tested with a 235 MiB pickle).
- `pytest tests/`: 149 passed, 8 skipped.
