### PR TITLE
Fix keys/values/items with a prefix on KEY_SEQUENCE automatons

### DIFF
--- a/src/Automaton.c
+++ b/src/Automaton.c
@@ -744,9 +744,20 @@ automaton_items_create(PyObject* self, PyObject* args, const ItemsType type) {
         arg1 = NULL;
 
     if (arg1) {
-        arg1 = pymod_get_string(arg1, &word, &wordlen, &word_is_copy);
-        if (arg1 == NULL)
-            goto error;
+        if (automaton->key_type == KEY_STRING) {
+            arg1 = pymod_get_string(arg1, &word, &wordlen, &word_is_copy);
+            if (arg1 == NULL)
+                goto error;
+        }
+        else {
+            // KEY_SEQUENCE: the prefix is a tuple of integers, not a string,
+            // so it has to go through pymod_get_sequence like add_word/get/etc do.
+            word_is_copy = true;
+            if (!pymod_get_sequence(arg1, &word, &wordlen)) {
+                arg1 = NULL;
+                goto error;
+            }
+        }
     }
     else {
         PyErr_Clear();

--- a/tests/test_issue_216.py
+++ b/tests/test_issue_216.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""
+    Aho-Corasick string search algorithm.
+
+    Author    : Wojciech Muła, wojciech_mula@poczta.onet.pl
+    WWW       : http://0x80.pl
+    License   : public domain
+"""
+
+import ahocorasick
+
+
+def build_int_sequence_automaton():
+    A = ahocorasick.Automaton(ahocorasick.STORE_ANY, ahocorasick.KEY_SEQUENCE)
+    A.add_word((1, 2), "val_for_1_2")
+    A.add_word((1, 2, 3), "val_for_1_2_3")
+    A.add_word((1, 2, 4, 5), "val_for_1_2_4_5")
+    A.add_word((1, 3), "val_for_1_3")
+    A.add_word((5,), "val_for_5")
+    return A
+
+
+def test_issue_216_keys_with_prefix_on_key_sequence():
+    A = build_int_sequence_automaton()
+
+    result = set(A.keys((1, 2)))
+
+    assert result == {"\x01\x02", "\x01\x02\x03", "\x01\x02\x04\x05"}
+
+
+def test_issue_216_values_with_prefix_on_key_sequence():
+    A = build_int_sequence_automaton()
+
+    result = set(A.values((1, 2)))
+
+    assert result == {"val_for_1_2", "val_for_1_2_3", "val_for_1_2_4_5"}
+
+
+def test_issue_216_items_with_prefix_on_key_sequence():
+    A = build_int_sequence_automaton()
+
+    result = set(A.items((1, 2)))
+
+    assert result == {
+        ("\x01\x02", "val_for_1_2"),
+        ("\x01\x02\x03", "val_for_1_2_3"),
+        ("\x01\x02\x04\x05", "val_for_1_2_4_5"),
+    }
+
+
+def test_issue_216_keys_without_prefix_on_key_sequence_still_works():
+    A = build_int_sequence_automaton()
+
+    result = set(A.keys())
+
+    assert result == {
+        "\x01\x02",
+        "\x01\x02\x03",
+        "\x01\x02\x04\x05",
+        "\x01\x03",
+        "\x05",
+    }


### PR DESCRIPTION
Fixes #216.

`automaton_items_create()` (backing `keys()`, `values()` and `items()`) always parses its prefix argument with `pymod_get_string()`, which only accepts str/bytes objects. That's correct for the default `KEY_STRING` automatons, but automatons built with `KEY_SEQUENCE` use tuples of ints as keys, so passing a prefix tuple to any of the three raises `TypeError: string expected`, even though the same tuple works fine with `get()`, `__contains__`, `longest_prefix`, etc.

Those other methods all go through `prepare_input()`, which branches on `automaton->key_type` and calls `pymod_get_sequence()` when the automaton is `KEY_SEQUENCE`. `automaton_items_create()` never got that treatment because it parses its own prefix/wildcard/how arguments directly rather than going through `prepare_input()`. This adds the same branch there for the prefix argument, mirroring what `prepare_input()` already does, and frees the resulting sequence copy the same way `word_is_copy` already does for the string path.

I left the `wildcard` argument alone since it's documented as a single-character string regardless of key type, so that's a separate, unrelated question.

Added `tests/test_issue_216.py` covering `keys()`/`values()`/`items()` with and without a prefix on a `KEY_SEQUENCE` automaton, plus a check that plain `KEY_STRING` prefix matching still works. Ran the full suite locally (`pytest tests/`), 153 passed / 8 skipped (the skips are the usual bytes-mode variants that don't apply to this build).