### PR TITLE
fix: complete iter_long failure traversal

### DIFF
--- a/src/AutomatonSearchIterLong.c
+++ b/src/AutomatonSearchIterLong.c
@@ -68,6 +68,20 @@ automaton_search_iter_long_iter(PyObject* self) {
 }
 
 
+static bool
+trienode_has_output_on_fail_path(TrieNode* node, TrieNode* root) {
+    node = node->fail;
+    while (node && node != root) {
+        if (node->eow)
+            return true;
+
+        node = node->fail;
+    }
+
+    return false;
+}
+
+
 static PyObject*
 automaton_build_output_iter_long(PyObject* self) {
 
@@ -116,7 +130,17 @@ return_output:
     }
 
     iter->index += 1;
-    while (iter->index < iter->end) {
+    while (true) {
+        if (iter->index >= iter->end) {
+            if (iter->last_node) {
+                goto return_output;
+            } else if (fail_node) {
+                fail_flag = true;
+            } else {
+                break;
+            }
+        }
+
         if (fail_flag) {
             // when failover start from fail node instead of next
             next = fail_node->fail;
@@ -132,7 +156,8 @@ return_output:
                 // save the last node on the path
                 iter->last_node  = next;
                 iter->last_index = iter->index;
-            } else if (!iter->last_node && !fail_node && next->fail && next->fail != iter->automaton->root && next->fail->eow) {
+            } else if (!iter->last_node && !fail_node &&
+                       trienode_has_output_on_fail_path(next, iter->automaton->root)) {
                 fail_node = next;
                 fail_index = iter->index;
             }
@@ -160,11 +185,7 @@ return_output:
                 }
             }
         }
-    } // while 
-
-    if (iter->last_node) {
-        goto return_output;
-    }
+    } // while
     
     return NULL;    // StopIteration
 }

--- a/tests/test_iter_long.py
+++ b/tests/test_iter_long.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+"""Regression tests for longest, non-overlapping iteration."""
+
+import ahocorasick
+
+from pytestingutils import conv
+
+
+def iter_long(patterns, text):
+    automaton = ahocorasick.Automaton()
+    for pattern in patterns:
+        automaton.add_word(conv(pattern), pattern)
+    automaton.make_automaton()
+
+    return list(automaton.iter_long(conv(text)))
+
+
+def test_match_reached_via_failure_link_at_end_of_input():
+    assert iter_long(["abc", "b"], "ab") == [(1, "b")]
+
+
+def test_match_reached_via_multiple_failure_links_on_mismatch():
+    assert iter_long(["abcd", "bcx", "c"], "abcz") == [(2, "c")]


### PR DESCRIPTION
# Summary

Fix `Automaton.iter_long()` so it consistently returns leftmost-longest, non-overlapping matches.

Previously, valid matches could be omitted when they were found through a failure link at the end of the input or through multiple failure links after a mismatch.

Inconsistency found while I was developing https://github.com/thevilledev/ocaml-aho-corasick and comparing outputs across implementations.

# Changes

- Traverse the complete failure chain when looking for a pending match.
- Process pending failure-chain matches when the input ends.
- Add regression tests for:
  - A match reached through a failure link at end of input.
  - A match reached through multiple failure links after a mismatch.

# Tests

- Confirmed both regression tests fail before the fix and pass afterward.
- Validated 574,675 pattern/input combinations against a leftmost-longest reference implementation.